### PR TITLE
feat: implement pytest-xdist style parallel test execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "collection_literals"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
+checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
 
 [[package]]
 name = "colorchoice"
@@ -296,6 +296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +386,16 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -630,6 +646,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "glob",
+ "num_cpus",
  "regex",
  "ruff_python_ast",
  "ruff_python_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ glob = "0.3"
 regex = "1.10"
 ruff_python_parser = { path = "ruff/crates/ruff_python_parser" }
 ruff_python_ast = { path = "ruff/crates/ruff_python_ast" }
+num_cpus = "1.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,9 +11,47 @@ pub struct Args {
     #[arg(long, short, num_args = 0..)]
     pub env: Vec<String>,
 
+    /// Number of processes to run tests in parallel
+    #[arg(long, short = 'n', alias = "numprocesses")]
+    pub numprocesses: Option<String>,
+
+    /// Maximum number of worker processes
+    #[arg(long)]
+    pub maxprocesses: Option<usize>,
+
+    /// Distribution mode for parallel execution
+    #[arg(long, default_value = "load")]
+    pub dist: String,
+
     /// Arguments to pass directly to pytest
     #[arg(last = true)]
     pub pytest_args: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum NumProcesses {
+    Auto,
+    Logical,
+    Count(usize),
+}
+
+impl Args {
+    pub fn get_num_processes(&self) -> Option<NumProcesses> {
+        self.numprocesses.as_ref().map(|s| match s.as_str() {
+            "auto" => NumProcesses::Auto,
+            "logical" => NumProcesses::Logical,
+            _ => NumProcesses::Count(s.parse().unwrap_or(1)),
+        })
+    }
+
+    pub fn validate_dist(&self) -> Result<(), String> {
+        match self.dist.as_str() {
+            "load" => Ok(()),
+            other => Err(format!(
+                "Distribution mode '{other}' is not yet implemented. Only 'load' is supported."
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -28,6 +66,9 @@ mod tests {
         assert_eq!(args.package_manager, "python");
         assert!(args.env.is_empty());
         assert!(args.pytest_args.is_empty());
+        assert!(args.numprocesses.is_none());
+        assert!(args.maxprocesses.is_none());
+        assert_eq!(args.dist, "load");
     }
 
     #[test]
@@ -79,5 +120,56 @@ mod tests {
         assert!(help.to_string().contains("package-manager"));
         assert!(help.to_string().contains("env"));
         assert!(help.to_string().contains("PYTEST_ARGS"));
+    }
+
+    #[test]
+    fn test_cli_parsing_with_numprocesses() {
+        let args = Args::parse_from(["rustic", "-n", "4"]);
+        assert_eq!(args.numprocesses, Some("4".to_string()));
+
+        let args = Args::parse_from(["rustic", "--numprocesses", "auto"]);
+        assert_eq!(args.numprocesses, Some("auto".to_string()));
+    }
+
+    #[test]
+    fn test_cli_parsing_with_maxprocesses() {
+        let args = Args::parse_from(["rustic", "--maxprocesses", "8"]);
+        assert_eq!(args.maxprocesses, Some(8));
+    }
+
+    #[test]
+    fn test_cli_parsing_with_dist() {
+        let args = Args::parse_from(["rustic", "--dist", "load"]);
+        assert_eq!(args.dist, "load");
+    }
+
+    #[test]
+    fn test_get_num_processes() {
+        let args = Args::parse_from(["rustic", "-n", "auto"]);
+        assert!(matches!(args.get_num_processes(), Some(NumProcesses::Auto)));
+
+        let args = Args::parse_from(["rustic", "-n", "logical"]);
+        assert!(matches!(
+            args.get_num_processes(),
+            Some(NumProcesses::Logical)
+        ));
+
+        let args = Args::parse_from(["rustic", "-n", "4"]);
+        assert!(matches!(
+            args.get_num_processes(),
+            Some(NumProcesses::Count(4))
+        ));
+
+        let args = Args::parse_from(["rustic"]);
+        assert!(args.get_num_processes().is_none());
+    }
+
+    #[test]
+    fn test_validate_dist() {
+        let args = Args::parse_from(["rustic", "--dist", "load"]);
+        assert!(args.validate_dist().is_ok());
+
+        let args = Args::parse_from(["rustic", "--dist", "loadfile"]);
+        assert!(args.validate_dist().is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,6 @@ pub mod collection_integration;
 pub mod pytest_executor;
 pub mod python_discovery;
 pub mod runner;
+pub mod scheduler;
+pub mod utils;
+pub mod worker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,24 +6,35 @@ mod collection_integration;
 mod pytest_executor;
 mod python_discovery;
 mod runner;
+mod scheduler;
+mod utils;
+mod worker;
 
 use clap::Parser;
 use cli::Args;
 use collection_integration::{collect_tests_rust, display_collection_results};
 use pytest_executor::execute_tests;
 use runner::PytestRunner;
+use scheduler::{create_scheduler, DistributionMode};
 use std::env;
+use utils::determine_worker_count;
+use worker::WorkerPool;
 
 fn main() {
     let args = Args::parse();
 
+    if let Err(e) = args.validate_dist() {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+
+    let worker_count = determine_worker_count(args.get_num_processes(), args.maxprocesses);
+
     let runner = PytestRunner::new(args.package_manager, args.env);
 
-    // Use Rust-based collection
     let rootpath = env::current_dir().expect("Failed to get current directory");
     let test_nodes = collect_tests_rust(rootpath, &args.pytest_args);
 
-    // Display collection results for debugging
     display_collection_results(&test_nodes);
 
     if test_nodes.is_empty() {
@@ -31,10 +42,74 @@ fn main() {
         std::process::exit(0);
     }
 
-    execute_tests(
-        &runner.program,
-        &runner.initial_args,
-        test_nodes,
-        args.pytest_args,
-    );
+    if worker_count == 1 {
+        execute_tests(
+            &runner.program,
+            &runner.initial_args,
+            test_nodes,
+            args.pytest_args,
+        );
+    } else {
+        execute_tests_parallel(
+            &runner.program,
+            &runner.initial_args,
+            test_nodes,
+            args.pytest_args,
+            worker_count,
+            &args.dist,
+        );
+    }
+}
+
+fn execute_tests_parallel(
+    program: &str,
+    initial_args: &[String],
+    test_nodes: Vec<String>,
+    pytest_args: Vec<String>,
+    worker_count: usize,
+    dist_mode: &str,
+) {
+    println!("Running tests with {worker_count} workers using {dist_mode} distribution");
+
+    let distribution_mode = dist_mode.parse::<DistributionMode>().unwrap();
+    let scheduler = create_scheduler(distribution_mode);
+    let test_batches = scheduler.distribute_tests(test_nodes, worker_count);
+
+    if test_batches.is_empty() {
+        println!("No test batches to execute.");
+        std::process::exit(0);
+    }
+
+    let mut worker_pool = WorkerPool::new();
+
+    for (worker_id, tests) in test_batches.into_iter().enumerate() {
+        if !tests.is_empty() {
+            worker_pool.spawn_worker(
+                worker_id,
+                program.to_string(),
+                initial_args.to_vec(),
+                tests,
+                pytest_args.clone(),
+            );
+        }
+    }
+
+    let results = worker_pool.wait_for_all();
+
+    let mut overall_exit_code = 0;
+    for result in results {
+        println!("=== Worker {} ===", result.worker_id);
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
+        }
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
+
+        if result.exit_code != 0 {
+            overall_exit_code = result.exit_code;
+        }
+    }
+
+    std::process::exit(overall_exit_code);
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,199 @@
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub enum DistributionMode {
+    Load,
+    // Future implementations:
+    // LoadScope,
+    // LoadFile,
+    // LoadGroup,
+    // WorkSteal,
+}
+
+impl fmt::Display for DistributionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DistributionMode::Load => write!(f, "load"),
+        }
+    }
+}
+
+impl std::str::FromStr for DistributionMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "load" => Ok(DistributionMode::Load),
+            other => Err(format!(
+                "Distribution mode '{other}' is not yet implemented. Only 'load' is supported."
+            )),
+        }
+    }
+}
+
+pub trait Scheduler {
+    fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>>;
+}
+
+pub struct LoadScheduler;
+
+impl Scheduler for LoadScheduler {
+    fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>> {
+        if num_workers == 0 || tests.is_empty() {
+            return vec![];
+        }
+
+        if num_workers == 1 {
+            return vec![tests];
+        }
+
+        let mut workers: Vec<Vec<String>> = vec![Vec::new(); num_workers];
+
+        for (i, test) in tests.into_iter().enumerate() {
+            workers[i % num_workers].push(test);
+        }
+
+        workers.into_iter().filter(|w| !w.is_empty()).collect()
+    }
+}
+
+pub fn create_scheduler(mode: DistributionMode) -> Box<dyn Scheduler> {
+    match mode {
+        DistributionMode::Load => Box::new(LoadScheduler),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_distribution_mode_from_str() {
+        assert!(matches!(
+            "load".parse::<DistributionMode>(),
+            Ok(DistributionMode::Load)
+        ));
+        assert!("loadfile".parse::<DistributionMode>().is_err());
+    }
+
+    #[test]
+    fn test_load_scheduler_empty_tests() {
+        let scheduler = LoadScheduler;
+        let result = scheduler.distribute_tests(vec![], 4);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_load_scheduler_zero_workers() {
+        let scheduler = LoadScheduler;
+        let tests = vec!["test1".to_string(), "test2".to_string()];
+        let result = scheduler.distribute_tests(tests, 0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_load_scheduler_single_worker() {
+        let scheduler = LoadScheduler;
+        let tests = vec![
+            "test1".to_string(),
+            "test2".to_string(),
+            "test3".to_string(),
+        ];
+        let result = scheduler.distribute_tests(tests.clone(), 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], tests);
+    }
+
+    #[test]
+    fn test_load_scheduler_round_robin() {
+        let scheduler = LoadScheduler;
+        let tests = vec![
+            "test1".to_string(),
+            "test2".to_string(),
+            "test3".to_string(),
+            "test4".to_string(),
+            "test5".to_string(),
+        ];
+        let result = scheduler.distribute_tests(tests, 3);
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], vec!["test1", "test4"]);
+        assert_eq!(result[1], vec!["test2", "test5"]);
+        assert_eq!(result[2], vec!["test3"]);
+    }
+
+    #[test]
+    fn test_load_scheduler_more_workers_than_tests() {
+        let scheduler = LoadScheduler;
+        let tests = vec!["test1".to_string(), "test2".to_string()];
+        let result = scheduler.distribute_tests(tests, 5);
+
+        assert_eq!(result.len(), 2); // Only non-empty workers
+        assert_eq!(result[0], vec!["test1"]);
+        assert_eq!(result[1], vec!["test2"]);
+    }
+
+    #[test]
+    fn test_create_scheduler() {
+        let scheduler = create_scheduler(DistributionMode::Load);
+        let tests = vec!["test1".to_string(), "test2".to_string()];
+        let result = scheduler.distribute_tests(tests, 2);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_load_scheduler_consistent_distribution() {
+        let scheduler = LoadScheduler;
+        let tests = vec![
+            "test1".to_string(),
+            "test2".to_string(),
+            "test3".to_string(),
+            "test4".to_string(),
+        ];
+
+        // Test the same distribution multiple times - should be consistent
+        let result1 = scheduler.distribute_tests(tests.clone(), 2);
+        let result2 = scheduler.distribute_tests(tests.clone(), 2);
+
+        assert_eq!(result1, result2);
+        assert_eq!(result1[0], vec!["test1", "test3"]);
+        assert_eq!(result1[1], vec!["test2", "test4"]);
+    }
+
+    #[test]
+    fn test_load_scheduler_all_tests_distributed() {
+        let scheduler = LoadScheduler;
+        let tests = vec![
+            "test1".to_string(),
+            "test2".to_string(),
+            "test3".to_string(),
+            "test4".to_string(),
+            "test5".to_string(),
+        ];
+
+        let result = scheduler.distribute_tests(tests.clone(), 3);
+
+        let mut all_distributed_tests: Vec<String> = Vec::new();
+        for worker_tests in result {
+            all_distributed_tests.extend(worker_tests);
+        }
+
+        all_distributed_tests.sort();
+        let mut expected_tests = tests.clone();
+        expected_tests.sort();
+
+        assert_eq!(all_distributed_tests, expected_tests);
+    }
+
+    #[test]
+    fn test_distribution_mode_display() {
+        assert_eq!(format!("{}", DistributionMode::Load), "load");
+    }
+
+    #[test]
+    fn test_distribution_mode_from_str_error_message() {
+        let error = "invalid".parse::<DistributionMode>().unwrap_err();
+        assert!(error.contains("Distribution mode 'invalid' is not yet implemented"));
+        assert!(error.contains("Only 'load' is supported"));
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,98 @@
+use crate::cli::NumProcesses;
+
+pub fn determine_worker_count(
+    num_processes: Option<NumProcesses>,
+    max_processes: Option<usize>,
+) -> usize {
+    let desired = match num_processes {
+        Some(NumProcesses::Auto) => num_cpus::get_physical(),
+        Some(NumProcesses::Logical) => num_cpus::get(),
+        Some(NumProcesses::Count(n)) => n,
+        None => 1,
+    };
+
+    match max_processes {
+        Some(max) => desired.min(max),
+        None => desired,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_determine_worker_count_none() {
+        let count = determine_worker_count(None, None);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_determine_worker_count_with_max() {
+        let count = determine_worker_count(Some(NumProcesses::Count(8)), Some(4));
+        assert_eq!(count, 4);
+    }
+
+    #[test]
+    fn test_determine_worker_count_under_max() {
+        let count = determine_worker_count(Some(NumProcesses::Count(2)), Some(8));
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_determine_worker_count_auto() {
+        let count = determine_worker_count(Some(NumProcesses::Auto), None);
+        assert!(count >= 1);
+    }
+
+    #[test]
+    fn test_determine_worker_count_logical() {
+        let count = determine_worker_count(Some(NumProcesses::Logical), None);
+        assert!(count >= 1);
+    }
+
+    #[test]
+    fn test_determine_worker_count_auto_vs_logical() {
+        let auto_count = determine_worker_count(Some(NumProcesses::Auto), None);
+        let logical_count = determine_worker_count(Some(NumProcesses::Logical), None);
+
+        // Auto (physical cores) should be <= logical cores
+        assert!(auto_count <= logical_count);
+        assert!(auto_count >= 1);
+        assert!(logical_count >= 1);
+    }
+
+    #[test]
+    fn test_determine_worker_count_zero_max() {
+        let count = determine_worker_count(Some(NumProcesses::Count(4)), Some(0));
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_determine_worker_count_explicit_zero() {
+        let count = determine_worker_count(Some(NumProcesses::Count(0)), None);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_determine_worker_count_large_numbers() {
+        let count = determine_worker_count(Some(NumProcesses::Count(1000)), Some(500));
+        assert_eq!(count, 500);
+
+        let count = determine_worker_count(Some(NumProcesses::Count(100)), Some(1000));
+        assert_eq!(count, 100);
+    }
+
+    #[test]
+    fn test_determine_worker_count_auto_with_max() {
+        let count = determine_worker_count(Some(NumProcesses::Auto), Some(1));
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_determine_worker_count_logical_with_max() {
+        let count = determine_worker_count(Some(NumProcesses::Logical), Some(2));
+        assert!(count <= 2);
+        assert!(count >= 1);
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,294 @@
+use std::process::{Command, Stdio};
+use std::thread;
+
+#[derive(Debug)]
+pub struct WorkerResult {
+    pub worker_id: usize,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct WorkerPool {
+    workers: Vec<WorkerHandle>,
+}
+
+struct WorkerHandle {
+    id: usize,
+    handle: thread::JoinHandle<WorkerResult>,
+}
+
+impl Default for WorkerPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkerPool {
+    pub fn new() -> Self {
+        Self {
+            workers: Vec::new(),
+        }
+    }
+
+    pub fn spawn_worker(
+        &mut self,
+        worker_id: usize,
+        program: String,
+        initial_args: Vec<String>,
+        tests: Vec<String>,
+        pytest_args: Vec<String>,
+    ) {
+        let handle = thread::spawn(move || {
+            let mut cmd = Command::new(&program);
+
+            for arg in initial_args {
+                cmd.arg(arg);
+            }
+
+            for test in tests {
+                cmd.arg(test);
+            }
+
+            for arg in pytest_args {
+                cmd.arg(arg);
+            }
+
+            cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+            match cmd.output() {
+                Ok(output) => WorkerResult {
+                    worker_id,
+                    exit_code: output.status.code().unwrap_or(-1),
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                },
+                Err(e) => WorkerResult {
+                    worker_id,
+                    exit_code: -1,
+                    stdout: String::new(),
+                    stderr: format!("Failed to execute command: {e}"),
+                },
+            }
+        });
+
+        self.workers.push(WorkerHandle {
+            id: worker_id,
+            handle,
+        });
+    }
+
+    pub fn wait_for_all(self) -> Vec<WorkerResult> {
+        let mut results = Vec::new();
+
+        for worker in self.workers {
+            match worker.handle.join() {
+                Ok(result) => results.push(result),
+                Err(_) => {
+                    results.push(WorkerResult {
+                        worker_id: worker.id,
+                        exit_code: -1,
+                        stdout: String::new(),
+                        stderr: "Worker thread panicked".to_string(),
+                    });
+                }
+            }
+        }
+
+        results.sort_by_key(|r| r.worker_id);
+        results
+    }
+
+    #[allow(dead_code)]
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_worker_pool_creation() {
+        let pool = WorkerPool::new();
+        assert_eq!(pool.worker_count(), 0);
+    }
+
+    #[test]
+    fn test_worker_result_creation() {
+        let result = WorkerResult {
+            worker_id: 1,
+            exit_code: 0,
+            stdout: "test output".to_string(),
+            stderr: String::new(),
+        };
+        assert_eq!(result.worker_id, 1);
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "test output");
+    }
+
+    #[test]
+    fn test_spawn_and_wait_echo_command() {
+        let mut pool = WorkerPool::new();
+
+        // Use echo command for testing
+        pool.spawn_worker(
+            0,
+            "echo".to_string(),
+            vec![],
+            vec!["hello".to_string()],
+            vec!["world".to_string()],
+        );
+
+        assert_eq!(pool.worker_count(), 1);
+
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].worker_id, 0);
+        assert_eq!(results[0].exit_code, 0);
+        assert!(results[0].stdout.contains("hello"));
+        assert!(results[0].stdout.contains("world"));
+    }
+
+    #[test]
+    fn test_multiple_workers() {
+        let mut pool = WorkerPool::new();
+
+        // Spawn multiple echo workers
+        pool.spawn_worker(
+            0,
+            "echo".to_string(),
+            vec![],
+            vec!["worker0".to_string()],
+            vec![],
+        );
+
+        pool.spawn_worker(
+            1,
+            "echo".to_string(),
+            vec![],
+            vec!["worker1".to_string()],
+            vec![],
+        );
+
+        assert_eq!(pool.worker_count(), 2);
+
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 2);
+
+        // Results should be sorted by worker_id
+        assert_eq!(results[0].worker_id, 0);
+        assert_eq!(results[1].worker_id, 1);
+        assert!(results[0].stdout.contains("worker0"));
+        assert!(results[1].stdout.contains("worker1"));
+    }
+
+    #[test]
+    fn test_worker_failure() {
+        let mut pool = WorkerPool::new();
+
+        // Use a command that should fail
+        pool.spawn_worker(
+            0,
+            "false".to_string(), // Command that always exits with code 1
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].worker_id, 0);
+        assert_ne!(results[0].exit_code, 0); // Should be non-zero exit code
+    }
+
+    #[test]
+    fn test_worker_with_initial_args() {
+        let mut pool = WorkerPool::new();
+
+        // Test with initial args (like "python -m pytest")
+        pool.spawn_worker(
+            0,
+            "echo".to_string(),
+            vec!["initial".to_string(), "args".to_string()],
+            vec!["test1".to_string()],
+            vec!["final".to_string()],
+        );
+
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].exit_code, 0);
+
+        let output = &results[0].stdout;
+        assert!(output.contains("initial"));
+        assert!(output.contains("args"));
+        assert!(output.contains("test1"));
+        assert!(output.contains("final"));
+    }
+
+    #[test]
+    fn test_worker_invalid_command() {
+        let mut pool = WorkerPool::new();
+
+        // Use a command that doesn't exist
+        pool.spawn_worker(
+            0,
+            "nonexistent_command_12345".to_string(),
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].worker_id, 0);
+        assert_eq!(results[0].exit_code, -1);
+        assert!(results[0].stderr.contains("Failed to execute command"));
+    }
+
+    #[test]
+    fn test_worker_result_sorting() {
+        let mut pool = WorkerPool::new();
+
+        // Spawn workers in reverse order
+        pool.spawn_worker(
+            2,
+            "echo".to_string(),
+            vec![],
+            vec!["worker2".to_string()],
+            vec![],
+        );
+
+        pool.spawn_worker(
+            0,
+            "echo".to_string(),
+            vec![],
+            vec!["worker0".to_string()],
+            vec![],
+        );
+
+        pool.spawn_worker(
+            1,
+            "echo".to_string(),
+            vec![],
+            vec!["worker1".to_string()],
+            vec![],
+        );
+
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 3);
+
+        // Should be sorted by worker_id regardless of spawn order
+        assert_eq!(results[0].worker_id, 0);
+        assert_eq!(results[1].worker_id, 1);
+        assert_eq!(results[2].worker_id, 2);
+    }
+
+    #[test]
+    fn test_empty_worker_pool() {
+        let pool = WorkerPool::new();
+        let results = pool.wait_for_all();
+        assert!(results.is_empty());
+    }
+}

--- a/tests/cli_parallel_options.rs
+++ b/tests/cli_parallel_options.rs
@@ -1,0 +1,125 @@
+use std::process::Command;
+
+#[test]
+fn test_cli_help_includes_parallel_options() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should include new parallel execution options
+    assert!(stdout.contains("numprocesses"));
+    assert!(stdout.contains("maxprocesses"));
+    assert!(stdout.contains("dist"));
+    assert!(stdout.contains("Number of processes to run tests in parallel"));
+    assert!(stdout.contains("Maximum number of worker processes"));
+    assert!(stdout.contains("Distribution mode for parallel execution"));
+}
+
+#[test]
+fn test_invalid_distribution_mode_error() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--dist", "loadfile"])
+        .output()
+        .expect("Failed to execute command");
+
+    // Should fail with proper error message
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Should have proper error message about unsupported distribution mode
+    assert!(
+        stderr.contains("Distribution mode 'loadfile' is not yet implemented")
+            || stderr.contains("Only 'load' is supported")
+    );
+}
+
+#[test]
+fn test_valid_distribution_mode_load() {
+    // Test that load mode is accepted (even if pytest fails)
+    let output = Command::new("cargo")
+        .args(["run", "--", "--dist", "load"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Should NOT have distribution mode error
+    assert!(!stderr.contains("Distribution mode 'load' is not yet implemented"));
+}
+
+#[test]
+fn test_numprocesses_argument_parsing() {
+    // Test various numprocesses values are accepted
+    let test_cases = ["1", "2", "4", "auto", "logical"];
+
+    for &num_processes in &test_cases {
+        let output = Command::new("cargo")
+            .args(["run", "--", "-n", num_processes])
+            .output()
+            .expect("Failed to execute command");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Should not have argument parsing errors
+        assert!(!stderr.contains("error: invalid value"));
+        assert!(!stderr.contains("argument"));
+    }
+}
+
+#[test]
+fn test_maxprocesses_argument_parsing() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--maxprocesses", "4"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Should not have argument parsing errors
+    assert!(!stderr.contains("error: invalid value"));
+    assert!(!stderr.contains("argument"));
+}
+
+#[test]
+fn test_combined_parallel_arguments() {
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "-n",
+            "4",
+            "--maxprocesses",
+            "2",
+            "--dist",
+            "load",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Should not have argument parsing errors
+    assert!(!stderr.contains("error: invalid value"));
+    assert!(!stderr.contains("argument"));
+    // Should not have distribution mode errors
+    assert!(!stderr.contains("Distribution mode"));
+}
+
+#[test]
+fn test_cli_version_still_works() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--version"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should show version information
+    assert!(stdout.contains("rustic") || stdout.contains("0.1.0"));
+}

--- a/tests/documentation_examples.rs
+++ b/tests/documentation_examples.rs
@@ -1,0 +1,131 @@
+// Tests to verify that examples in documentation work correctly
+
+use std::process::Command;
+
+#[test]
+fn test_basic_usage_examples() {
+    // Test basic sequential usage (should work even without pytest)
+    let output = Command::new("cargo")
+        .args(["run", "--", "--help"])
+        .output()
+        .expect("Failed to execute help command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: rustic"));
+}
+
+#[test]
+fn test_parallel_usage_examples() {
+    // These are the basic usage patterns that should be documented
+
+    let test_cases = vec![
+        // Basic parallel execution
+        vec!["-n", "2"],
+        // Auto CPU detection
+        vec!["-n", "auto"],
+        // Logical CPU detection
+        vec!["-n", "logical"],
+        // With max processes limit
+        vec!["-n", "4", "--maxprocesses", "2"],
+        // Explicit load distribution
+        vec!["--dist", "load"],
+        // Combined options
+        vec!["-n", "3", "--dist", "load", "--maxprocesses", "4"],
+    ];
+
+    for args in test_cases {
+        let mut cmd_args = vec!["run", "--"];
+        cmd_args.extend(args.iter());
+
+        let output = Command::new("cargo")
+            .args(cmd_args)
+            .output()
+            .expect("Failed to execute command");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Should not have argument parsing errors
+        assert!(
+            !stderr.contains("error: invalid value"),
+            "Command failed with args {args:?}: {stderr}"
+        );
+        assert!(
+            !stderr.contains("error: unexpected argument"),
+            "Command failed with args {args:?}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn test_error_cases_examples() {
+    // Test that documented error cases work as expected
+
+    // Invalid distribution mode
+    let output = Command::new("cargo")
+        .args(["run", "--", "--dist", "invalid"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not yet implemented") || stderr.contains("Only 'load' is supported"));
+}
+
+#[test]
+fn test_version_and_help_accessibility() {
+    // Ensure basic documentation commands work
+
+    let version_output = Command::new("cargo")
+        .args(["run", "--", "--version"])
+        .output()
+        .expect("Failed to execute version command");
+
+    assert!(version_output.status.success());
+
+    let help_output = Command::new("cargo")
+        .args(["run", "--", "--help"])
+        .output()
+        .expect("Failed to execute help command");
+
+    assert!(help_output.status.success());
+    let help_text = String::from_utf8_lossy(&help_output.stdout);
+
+    // Should contain key usage information
+    assert!(help_text.contains("numprocesses"));
+    assert!(help_text.contains("maxprocesses"));
+    assert!(help_text.contains("dist"));
+}
+
+#[test]
+fn test_pytest_passthrough_args() {
+    // Test that pytest arguments are properly passed through
+    let output = Command::new("cargo")
+        .args(["run", "--", "-n", "2", "--", "-v", "--tb=short"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Should not have argument parsing errors for pytest args
+    assert!(!stderr.contains("error: invalid value"));
+    assert!(!stderr.contains("error: unexpected argument"));
+}
+
+#[test]
+fn test_package_manager_integration() {
+    // Test that parallel execution works with different package managers
+    let package_managers = ["python", "uv", "pipenv", "poetry"];
+
+    for pm in package_managers {
+        let output = Command::new("cargo")
+            .args(["run", "--", "--package-manager", pm, "-n", "2"])
+            .output()
+            .expect("Failed to execute command");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Should accept the package manager argument
+        assert!(!stderr.contains("error: invalid value"));
+    }
+}

--- a/tests/unit_parallel_logic.rs
+++ b/tests/unit_parallel_logic.rs
@@ -1,0 +1,185 @@
+// Unit tests for parallel execution logic that don't require external dependencies
+
+#[cfg(test)]
+mod parallel_logic_tests {
+    use rustic::cli::NumProcesses;
+    use rustic::scheduler::{create_scheduler, DistributionMode, LoadScheduler, Scheduler};
+    use rustic::utils::determine_worker_count;
+    use rustic::worker::{WorkerPool, WorkerResult};
+
+    #[test]
+    fn test_end_to_end_test_distribution() {
+        // Test the complete flow from CLI args to test distribution
+        let tests = vec![
+            "test_file1.py::test_function1".to_string(),
+            "test_file1.py::test_function2".to_string(),
+            "test_file2.py::TestClass::test_method1".to_string(),
+            "test_file2.py::TestClass::test_method2".to_string(),
+            "test_file3.py::test_function3".to_string(),
+        ];
+
+        // Simulate -n 3
+        let num_processes = Some(NumProcesses::Count(3));
+        let max_processes = None;
+        let worker_count = determine_worker_count(num_processes, max_processes);
+        assert_eq!(worker_count, 3);
+
+        // Test distribution
+        let scheduler = create_scheduler(DistributionMode::Load);
+        let batches = scheduler.distribute_tests(tests.clone(), worker_count);
+
+        // Should have 3 batches
+        assert_eq!(batches.len(), 3);
+
+        // All tests should be distributed
+        let total_distributed: usize = batches.iter().map(|batch| batch.len()).sum();
+        assert_eq!(total_distributed, tests.len());
+
+        // Each batch should have at least one test (since we have 5 tests and 3 workers)
+        for batch in &batches {
+            assert!(!batch.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_worker_count_determination_edge_cases() {
+        // Test auto with max limit
+        let worker_count = determine_worker_count(Some(NumProcesses::Auto), Some(1));
+        assert_eq!(worker_count, 1);
+
+        // Test explicit count with max limit
+        let worker_count = determine_worker_count(Some(NumProcesses::Count(10)), Some(3));
+        assert_eq!(worker_count, 3);
+
+        // Test zero max processes
+        let worker_count = determine_worker_count(Some(NumProcesses::Count(5)), Some(0));
+        assert_eq!(worker_count, 0);
+    }
+
+    #[test]
+    fn test_load_scheduler_properties() {
+        let scheduler = LoadScheduler;
+
+        // Test deterministic distribution
+        let tests = vec![
+            "test1".to_string(),
+            "test2".to_string(),
+            "test3".to_string(),
+            "test4".to_string(),
+            "test5".to_string(),
+            "test6".to_string(),
+        ];
+
+        let result1 = scheduler.distribute_tests(tests.clone(), 3);
+        let result2 = scheduler.distribute_tests(tests.clone(), 3);
+
+        // Should be deterministic
+        assert_eq!(result1, result2);
+
+        // Should distribute evenly
+        assert_eq!(result1[0].len(), 2); // test1, test4
+        assert_eq!(result1[1].len(), 2); // test2, test5
+        assert_eq!(result1[2].len(), 2); // test3, test6
+    }
+
+    #[test]
+    fn test_scheduler_with_more_workers_than_tests() {
+        let scheduler = LoadScheduler;
+        let tests = vec!["test1".to_string(), "test2".to_string()];
+
+        let result = scheduler.distribute_tests(tests, 5);
+
+        // Should only return non-empty batches
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], vec!["test1"]);
+        assert_eq!(result[1], vec!["test2"]);
+    }
+
+    #[test]
+    fn test_worker_pool_basic_functionality() {
+        let mut pool = WorkerPool::new();
+
+        // Test initial state
+        assert_eq!(pool.worker_count(), 0);
+
+        // Spawn a simple echo worker
+        pool.spawn_worker(
+            0,
+            "echo".to_string(),
+            vec!["hello".to_string()],
+            vec!["test".to_string()],
+            vec!["world".to_string()],
+        );
+
+        assert_eq!(pool.worker_count(), 1);
+
+        // Wait for completion
+        let results = pool.wait_for_all();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].worker_id, 0);
+    }
+
+    #[test]
+    fn test_distribution_mode_parsing() {
+        // Test valid mode
+        let mode = "load".parse::<DistributionMode>();
+        assert!(mode.is_ok());
+        assert!(matches!(mode.unwrap(), DistributionMode::Load));
+
+        // Test invalid modes
+        let invalid_modes = ["loadfile", "loadscope", "loadgroup", "worksteal", "invalid"];
+        for invalid_mode in invalid_modes {
+            let result = invalid_mode.parse::<DistributionMode>();
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.contains("not yet implemented"));
+            assert!(error.contains("Only 'load' is supported"));
+        }
+    }
+
+    #[test]
+    fn test_realistic_test_distribution_scenario() {
+        // Simulate a realistic test suite
+        let mut tests = Vec::new();
+
+        // Add function tests
+        for i in 1..=10 {
+            tests.push(format!("test_module_{}.py::test_function_{i}", i % 3 + 1));
+        }
+
+        // Add class-based tests
+        for i in 1..=8 {
+            tests.push(format!("test_classes.py::TestClass{i}::test_method"));
+        }
+
+        let scheduler = LoadScheduler;
+        let result = scheduler.distribute_tests(tests.clone(), 4);
+
+        // Should have 4 workers
+        assert_eq!(result.len(), 4);
+
+        // All tests should be distributed
+        let total_tests: usize = result.iter().map(|batch| batch.len()).sum();
+        assert_eq!(total_tests, tests.len());
+
+        // Each worker should have roughly equal load (within 1 test)
+        let max_batch_size = result.iter().map(|batch| batch.len()).max().unwrap();
+        let min_batch_size = result.iter().map(|batch| batch.len()).min().unwrap();
+        assert!(max_batch_size - min_batch_size <= 1);
+    }
+
+    #[test]
+    fn test_worker_result_structure() {
+        let result = WorkerResult {
+            worker_id: 1,
+            exit_code: 0,
+            stdout: "Test output".to_string(),
+            stderr: String::new(),
+        };
+
+        assert_eq!(result.worker_id, 1);
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "Test output");
+        assert!(result.stderr.is_empty());
+    }
+}


### PR DESCRIPTION
Add comprehensive parallel test execution capabilities inspired by `pytest-xdist`, enabling distributed test running across multiple worker processes. This implementation provides the basic `'load'` scheduling algorithm with round-robin test distribution, automatic CPU detection, and configurable worker limits. The architecture is designed for easy extension to support additional scheduling algorithms (`loadscope`, `loadfile`, `loadgroup`, `worksteal`) in future iterations.

Implementation details:
* Add CLI options: `-n/--numprocesses` (auto/logical/count), `--maxprocesses`, `--dist` 
* Implement `LoadScheduler` with round-robin test distribution across workers 
* Create `WorkerPool` for spawning and managing multiple `pytest` subprocess workers 
* Add CPU detection utilities supporting both physical and logical core counts 
* Integrate parallel execution into main flow with fallback to sequential mode 