### PR TITLE
feat: skip test class collection when __init__ method is present

### DIFF
--- a/src/python_discovery/discovery.rs
+++ b/src/python_discovery/discovery.rs
@@ -109,4 +109,27 @@ class NotATestClass:
         assert!(tests[1].is_method);
         assert_eq!(tests[1].class_name, Some("TestClass".to_string()));
     }
+
+    #[test]
+    fn test_skip_classes_with_init() {
+        let source = r#"
+class TestWithInit:
+    def __init__(self):
+        pass
+        
+    def test_should_be_skipped(self):
+        pass
+
+class TestWithoutInit:
+    def test_should_be_collected(self):
+        pass
+"#;
+
+        let config = TestDiscoveryConfig::default();
+        let tests = discover_tests(&PathBuf::from("test.py"), source, &config).unwrap();
+
+        assert_eq!(tests.len(), 1);
+        assert_eq!(tests[0].name, "test_should_be_collected");
+        assert_eq!(tests[0].class_name, Some("TestWithoutInit".to_string()));
+    }
 }

--- a/src/python_discovery/visitor.rs
+++ b/src/python_discovery/visitor.rs
@@ -54,7 +54,7 @@ impl TestDiscoveryVisitor {
 
     fn visit_class(&mut self, class: &StmtClassDef) {
         let name = class.name.as_str();
-        if self.is_test_class(name) {
+        if self.is_test_class(name) && !self.class_has_init(class) {
             let prev_class = self.current_class.clone();
             self.current_class = Some(name.to_string());
 
@@ -80,6 +80,17 @@ impl TestDiscoveryVisitor {
         for pattern in &self.config.python_classes {
             if pattern::matches(pattern, name) {
                 return true;
+            }
+        }
+        false
+    }
+
+    fn class_has_init(&self, class: &StmtClassDef) -> bool {
+        for stmt in &class.body {
+            if let Stmt::FunctionDef(func) = stmt {
+                if func.name.as_str() == "__init__" {
+                    return true;
+                }
             }
         }
         false


### PR DESCRIPTION
Add logic to exclude test classes that define `__init__` methods from test discovery, as these classes typically require instantiation parameters and are not suitable for automated test execution. This prevents test runners from attempting to instantiate classes that may fail due to missing constructor arguments.

- Add `class_has_init()` method to check for `__init__` presence
- Update `visit_class()` to skip classes with `__init__` methods