### PR TITLE
feat: implement fatal error handling for Python parse errors

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -411,6 +411,7 @@ pub struct CollectReport {
     pub nodeid: String,
     pub outcome: CollectionOutcome,
     pub longrepr: Option<String>,
+    pub error_type: Option<CollectionError>,
     pub result: Vec<Box<dyn Collector>>,
 }
 
@@ -419,12 +420,14 @@ impl CollectReport {
         nodeid: String,
         outcome: CollectionOutcome,
         longrepr: Option<String>,
+        error_type: Option<CollectionError>,
         result: Vec<Box<dyn Collector>>,
     ) -> Self {
         Self {
             nodeid,
             outcome,
             longrepr,
+            error_type,
             result,
         }
     }
@@ -459,12 +462,14 @@ pub fn collect_one_node(collector: &dyn Collector) -> CollectReport {
             collector.nodeid().to_string(),
             CollectionOutcome::Passed,
             None,
+            None,
             result,
         ),
         Err(e) => CollectReport::new(
             collector.nodeid().to_string(),
             CollectionOutcome::Failed,
             Some(e.to_string()),
+            Some(e),
             vec![],
         ),
     }

--- a/src/collection_integration.rs
+++ b/src/collection_integration.rs
@@ -1,10 +1,16 @@
 //! Integration between Rust collection and pytest execution.
 
-use crate::collection::{collect_one_node, Collector, Session};
+use crate::collection::{collect_one_node, CollectionError, Collector, Session};
 use std::path::PathBuf;
 
+/// Result type for collection operations
+pub type CollectionIntegrationResult<T> = Result<T, CollectionError>;
+
 /// Run the Rust-based collection and return test node IDs
-pub fn collect_tests_rust(rootpath: PathBuf, args: &[String]) -> Vec<String> {
+pub fn collect_tests_rust(
+    rootpath: PathBuf,
+    args: &[String],
+) -> CollectionIntegrationResult<Vec<String>> {
     let mut session = Session::new(rootpath);
 
     match session.perform_collect(args) {
@@ -12,27 +18,45 @@ pub fn collect_tests_rust(rootpath: PathBuf, args: &[String]) -> Vec<String> {
             let mut test_nodes = Vec::new();
 
             for collector in collectors {
-                collect_items_recursive(collector.as_ref(), &mut test_nodes);
+                collect_items_recursive(collector.as_ref(), &mut test_nodes)?;
             }
 
-            test_nodes
+            Ok(test_nodes)
         }
-        Err(e) => {
-            eprintln!("Collection error: {e}");
-            vec![]
-        }
+        Err(e) => Err(e),
     }
 }
 
 /// Recursively collect all test items
-fn collect_items_recursive(collector: &dyn Collector, test_nodes: &mut Vec<String>) {
+fn collect_items_recursive(
+    collector: &dyn Collector,
+    test_nodes: &mut Vec<String>,
+) -> CollectionIntegrationResult<()> {
     if collector.is_item() {
         test_nodes.push(collector.nodeid().to_string());
+        Ok(())
     } else {
         let report = collect_one_node(collector);
-        if matches!(report.outcome, crate::collection::CollectionOutcome::Passed) {
-            for child in report.result {
-                collect_items_recursive(child.as_ref(), test_nodes);
+        match report.outcome {
+            crate::collection::CollectionOutcome::Passed => {
+                for child in report.result {
+                    collect_items_recursive(child.as_ref(), test_nodes)?;
+                }
+                Ok(())
+            }
+            crate::collection::CollectionOutcome::Failed => {
+                if let Some(error) = report.error_type {
+                    // Check if this is a parse error that should cause failure
+                    if matches!(error, crate::collection::CollectionError::ParseError(_)) {
+                        return Err(error);
+                    }
+                }
+                // For non-parse errors, continue silently
+                Ok(())
+            }
+            _ => {
+                // Handle other outcomes (Skipped, etc.) - continue silently
+                Ok(())
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,13 @@ fn main() {
     let runner = PytestRunner::new(args.package_manager, args.env);
 
     let rootpath = env::current_dir().expect("Failed to get current directory");
-    let test_nodes = collect_tests_rust(rootpath, &args.pytest_args);
+    let test_nodes = match collect_tests_rust(rootpath, &args.pytest_args) {
+        Ok(nodes) => nodes,
+        Err(e) => {
+            eprintln!("FATAL: {e}");
+            std::process::exit(1);
+        }
+    };
 
     display_collection_results(&test_nodes);
 

--- a/tests/real_file_integration.rs
+++ b/tests/real_file_integration.rs
@@ -59,7 +59,7 @@ def process_data(data):
     fs::write(&test_file_path, real_pytest_content).expect("Failed to write test file");
 
     // Collect tests
-    let test_nodes = collect_tests_rust(project_path, &[]);
+    let test_nodes = collect_tests_rust(project_path, &[]).expect("Collection should succeed");
 
     println!("Found {} test nodes:", test_nodes.len());
     for node in &test_nodes {


### PR DESCRIPTION
Modify rustic to raise fatal errors when encountering invalid Python syntax during test collection, matching `pytest`'s behavior. Previously, parse errors were silently skipped, but now they cause collection to fail with a clear error message.

- Enhanced `CollectReport` to preserve original `CollectionError` types alongside error messages
- Modified `collect_tests_rust` to return `Result<Vec<String>, CollectionError>` instead of `Vec<String>`
- Updated error detection to use type matching instead of fragile string pattern matching
- Moved process exit handling from collection logic to main entry point for better separation of concerns