### PR TITLE
feat: collect all syntax errors instead of failing fast

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -354,10 +354,13 @@ impl Collector for Module {
             python_functions: self.session().config.python_functions.clone(),
         };
 
-        // Discover tests in the file
-        let tests = discover_tests(&self.path, &source, &discovery_config)?;
+        let tests = match discover_tests(&self.path, &source, &discovery_config) {
+            Ok(tests) => tests,
+            Err(e) => {
+                return Err(e);
+            }
+        };
 
-        // Convert test info to Function collectors
         let mut items: Vec<Box<dyn Collector>> = Vec::new();
         for test in tests {
             let function = test_info_to_function(&test, &self.path, &self.nodeid);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,15 +33,15 @@ fn main() {
     let runner = PytestRunner::new(args.package_manager, args.env);
 
     let rootpath = env::current_dir().expect("Failed to get current directory");
-    let test_nodes = match collect_tests_rust(rootpath, &args.pytest_args) {
-        Ok(nodes) => nodes,
+    let (test_nodes, errors) = match collect_tests_rust(rootpath, &args.pytest_args) {
+        Ok((nodes, errors)) => (nodes, errors),
         Err(e) => {
             eprintln!("FATAL: {e}");
             std::process::exit(1);
         }
     };
 
-    display_collection_results(&test_nodes);
+    display_collection_results(&test_nodes, &errors);
 
     if test_nodes.is_empty() {
         println!("No tests found.");

--- a/tests/real_file_integration.rs
+++ b/tests/real_file_integration.rs
@@ -59,7 +59,8 @@ def process_data(data):
     fs::write(&test_file_path, real_pytest_content).expect("Failed to write test file");
 
     // Collect tests
-    let test_nodes = collect_tests_rust(project_path, &[]).expect("Collection should succeed");
+    let (test_nodes, _errors) =
+        collect_tests_rust(project_path, &[]).expect("Collection should succeed");
 
     println!("Found {} test nodes:", test_nodes.len());
     for node in &test_nodes {

--- a/tests/test_multiple_errors.rs
+++ b/tests/test_multiple_errors.rs
@@ -1,0 +1,82 @@
+//! Test that multiple syntax errors are collected and reported
+
+use rustic::collection::CollectionError;
+use rustic::collection_integration::{collect_tests_rust, display_collection_results};
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_collection_multiple_syntax_errors() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let project_path = temp_dir.path().join("test_project");
+    fs::create_dir_all(&project_path).expect("Failed to create project directory");
+
+    let error_files = vec![
+        ("test_assert_empty.py", "assert"),
+        ("test_if_missing.py", "if : ...\n    pass"),
+        ("test_while_missing.py", "while : ...\n    pass"),
+    ];
+
+    for (filename, content) in &error_files {
+        let file_path = project_path.join(filename);
+        fs::write(&file_path, content).expect("Failed to write file");
+    }
+
+    let valid_content = r#"
+def test_valid():
+    assert True
+    
+class TestValidClass:
+    def test_method(self):
+        pass
+"#;
+    fs::write(project_path.join("test_valid.py"), valid_content).expect("Failed to write file");
+
+    println!("Files in project directory:");
+    for entry in std::fs::read_dir(&project_path).unwrap() {
+        let entry = entry.unwrap();
+        println!("  - {:?}", entry.path());
+    }
+
+    let result = collect_tests_rust(project_path, &[]);
+    assert!(
+        result.is_ok(),
+        "Should not fail immediately on syntax errors"
+    );
+
+    let (test_nodes, errors) = result.unwrap();
+
+    println!("Test nodes found: {test_nodes:?}");
+    println!("Errors found: {errors:?}");
+
+    assert_eq!(test_nodes.len(), 2, "Should find tests from valid file");
+    assert!(test_nodes
+        .iter()
+        .any(|n| n.contains("test_valid.py::test_valid")));
+    assert!(test_nodes
+        .iter()
+        .any(|n| n.contains("test_valid.py::TestValidClass::test_method")));
+
+    assert_eq!(errors.errors.len(), 3, "Should collect all 3 syntax errors");
+
+    for (filename, _) in &error_files {
+        assert!(
+            errors
+                .errors
+                .iter()
+                .any(|(nodeid, _)| nodeid.contains(filename)),
+            "Should have error for {filename}"
+        );
+    }
+
+    for (_, error) in &errors.errors {
+        assert!(
+            matches!(error, CollectionError::ParseError(_)),
+            "All errors should be parse errors"
+        );
+    }
+
+    println!("\n--- Test output ---");
+    display_collection_results(&test_nodes, &errors);
+    println!("--- End test output ---\n");
+}


### PR DESCRIPTION
Changed collection behavior to gather all syntax errors during test discovery instead of failing immediately on the first error. This provides better user experience by showing all issues at once, similar to pytest's behavior.

- Modified collection to accumulate errors in `CollectionErrors` struct
- Updated display to show error details with ANSI color formatting (red)