### PR TITLE
feat: add Python package with auto-detection of current environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'hughhan1/rustic'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
+
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release version && semantic-release publish
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(grep -o 'version = "[^"]*"' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Check if release was created
+        id: check_release
+        run: |
+          if git describe --exact-match --tags HEAD 2>/dev/null; then
+            echo "new_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "new_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build wheels
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+
+      - name: Upload wheels
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: dist
+
+      - name: Publish to PyPI
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+          before-script-linux: |
+            if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+              export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+            fi
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-latest
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  sdist:
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,0 +1,62 @@
+name: Test Release
+
+on:
+  push:
+    branches:
+      - develop
+      - test-release
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  test-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
+
+      - name: Check what would be released
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release version --noop
+
+      - name: Build wheels for testing
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+
+      - name: Upload to TestPyPI
+        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test-release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
+
+      - name: Test install from TestPyPI
+        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test-release'
+        run: |
+          sleep 60  # Wait for TestPyPI to process
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ rustic
+          python -c "import rustic; print('Test install successful')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-07-03
+
+### Added
+- **Resilient Test Collection**: Unlike pytest which stops execution when collection errors occur, Rustic continues running tests even when some files fail to collect, providing partial test results while fixing syntax errors
+- **Python Package Integration**: Auto-detection of current Python environment with seamless pytest integration
+- **Parallel Test Execution**: pytest-xdist style parallel test execution for improved performance
+- **Comprehensive Error Handling**: Collect all syntax errors instead of failing fast, allowing developers to see all issues at once
+- **Smart Test Filtering**: Outputs collected tests and filters test files with intelligent pattern matching
+- **Python Module and CLI Support**: Can be used both as a Python module (`from rustic import run_tests`) and as a CLI tool (`rustic`)
+- **Fatal Error Handling**: Robust handling of Python parse errors and collection failures
+
+### Features
+- Fast Python test runner built with Rust for superior performance
+- Maintains compatibility with existing pytest workflows and arguments
+- Supports Python 3.9+ with comprehensive type checking via mypy
+- MIT licensed with modern Python packaging using maturin
+
+## [Unreleased]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,197 @@
+Contributing to Rustic
+====================
+
+Thank you for your interest in contributing to Rustic! This document provides guidelines for contributors.
+
+Getting Started
+---------------
+
+1. Fork the repository on GitHub
+2. Clone your fork locally::
+
+    git clone https://github.com/yourusername/rustic.git
+    cd rustic
+
+3. Install development dependencies::
+
+    uv pip install -e ".[dev]"
+    uv pip install maturin
+
+4. Set up Rust toolchain::
+
+    rustup update stable
+
+Development Workflow
+--------------------
+
+1. Create a feature branch::
+
+    git checkout -b feature/your-feature-name
+
+2. Install in development mode::
+
+    maturin develop
+
+3. Run tests to ensure everything works::
+
+    uv run python -m unittest discover tests/ -v
+    cargo test
+
+4. Make your changes following our coding standards
+
+5. Run linting and type checking::
+
+    uv run ruff format python/ tests/
+    uv run ruff check python/ tests/
+    uv run mypy python/
+    cargo fmt
+    cargo clippy
+
+6. Commit your changes using conventional commits::
+
+    git commit -m "feat: add new feature description"
+
+7. Push to your fork and create a pull request
+
+Commit Messages
+--------------
+
+We use `Conventional Commits <https://www.conventionalcommits.org/>`_ for automated versioning:
+
+- ``feat: add new feature`` → minor version bump
+- ``fix: resolve bug`` → patch version bump  
+- ``feat!: breaking change`` → major version bump
+- ``docs: update documentation`` → no version bump
+
+Common types: ``feat``, ``fix``, ``docs``, ``style``, ``refactor``, ``test``, ``chore``
+
+Testing
+-------
+
+Run the full test suite::
+
+    # Python tests
+    uv run python -m unittest discover tests/ -v
+    
+    # Rust tests
+    cargo test
+    
+    # Integration tests
+    maturin develop
+    uv run python -c "import rustic; print('Import successful')"
+
+For maintainers, see the `Release Process`_ section below.
+
+Release Process
+---------------
+
+*This section is for maintainers only.*
+
+Overview
+~~~~~~~~
+
+Rustic uses automated semantic versioning with ``python-semantic-release``. Releases are triggered by conventional commits and published automatically to PyPI.
+
+Setup Requirements
+~~~~~~~~~~~~~~~~~~
+
+Repository secrets (Settings → Secrets and variables → Actions):
+
+- ``PYPI_API_TOKEN``: From `PyPI Account Settings <https://pypi.org/manage/account/token/>`_
+- ``TEST_PYPI_API_TOKEN``: From `TestPyPI Account Settings <https://test.pypi.org/manage/account/token/>`_
+
+Branch Workflow
+~~~~~~~~~~~~~~~
+
+- ``main`` branch: Production releases → PyPI
+- ``develop`` branch: Pre-releases → TestPyPI
+
+Testing Releases
+~~~~~~~~~~~~~~~~
+
+**Option 1: TestPyPI (Recommended)**
+
+1. Push to develop branch::
+
+    git checkout develop
+    git commit -m "feat: new feature for testing"
+    git push origin develop
+
+2. Install from TestPyPI::
+
+    uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ rustic
+
+**Option 2: Local Testing**
+
+::
+
+    maturin build --release --out dist
+    uv pip install dist/rustic-*.whl
+    uv run python -c "import rustic; print('Local test successful')"
+
+**Option 3: Dry Run**
+
+::
+
+    uv pip install python-semantic-release
+    semantic-release version --noop  # Shows what version would be released
+
+Production Releases
+~~~~~~~~~~~~~~~~~~~
+
+1. Test thoroughly on develop branch
+2. Merge to main::
+
+    git checkout main
+    git merge develop
+    git push origin main
+
+3. Release happens automatically:
+   - Version bumped in ``pyproject.toml``
+   - Changelog updated
+   - Git tag created
+   - GitHub release published
+   - Multi-platform wheels built
+   - Package published to PyPI
+
+Manual Release (Emergency)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    semantic-release version    # Update version and create tag
+    semantic-release publish    # Create GitHub release and publish to PyPI
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+**"No version to release"**: Ensure commits follow conventional format
+
+**Build failures**: Check Rust toolchain and Python environment::
+
+    rustup update
+    cargo check
+    maturin build --release
+
+**Upload failures**: Check for existing versions::
+
+    uv pip index versions rustic
+    uv pip index versions --index-url https://test.pypi.org/simple/ rustic
+
+Community
+---------
+
+- **Issues**: Report bugs and request features on GitHub
+- **Discussions**: Join conversations in GitHub Discussions
+- **Security**: Report security issues privately via GitHub Security tab
+
+Code of Conduct
+---------------
+
+This project follows the `Contributor Covenant Code of Conduct <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>`_. 
+By participating, you agree to uphold this code.
+
+License
+-------
+
+By contributing to Rustic, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hugh Han
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ collected 22 items / 3 errors
 **rustic behavior:**
 ```
 collected 22 items / 3 errors
-!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!! Warning: 3 errors during collection !!!!!!!!!!!!!!!!!!!!!
 ================================== test session starts ===================================
 # Continues to run the 22 successfully collected tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,16 @@ dev = [
     "maturin>=1.9.0",
 ]
 
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+changelog_file = "CHANGELOG.md"
+upload_to_repository = true
+upload_to_release = true
+hvcs = "github"
+branches = { main = "main", prerelease = "develop" }
+
+[tool.semantic_release.remote]
+type = "github"
+
+[tool.semantic_release.publish]
+dist_glob_patterns = ["dist/*"]

--- a/src/collection_integration.rs
+++ b/src/collection_integration.rs
@@ -92,7 +92,7 @@ pub fn display_collection_results(test_nodes: &[String], errors: &CollectionErro
             }
         }
         println!(
-            "!!!!!!!!!!!!!!!!!!!!! Interrupted: {} errors during collection !!!!!!!!!!!!!!!!!!!!!",
+            "!!!!!!!!!!!!!!!!!!!!! Warning: {} errors during collection !!!!!!!!!!!!!!!!!!!!!",
             errors.errors.len()
         );
     }


### PR DESCRIPTION
Sets up `rustic` as a Python package that automatically uses the current Python environment, removing the need for manual package manager configuration.

- Add Python package configuration and `maturin` build setup
- Auto-detect current Python executable instead of requiring package manager selection
- Remove `--package-manager` CLI argument for simplicity
- Add `pytest` as a dependency to ensure availability
- Fix `Cargo.toml` to use `cdylib` for Python extension
- Rewrite Rust integration tests in Python