### PR TITLE
Add Windows support to CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2019]
         # TODO(hughhan1): Add macOS runners back when budget allows
         # macos-13, macos-14 - currently disabled due to cost
         # As of July 2025, macOS runners cost 10x more than Linux runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, beta ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2019]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022]
         # TODO(hughhan1): Add macOS runners back when budget allows
         # macos-13, macos-14 - currently disabled due to cost
         # As of July 2025, macOS runners cost 10x more than Linux runners

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,41 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-2022
+            target: x64
+          - runner: windows-2019
+            target: x64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          submodules: recursive
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
   sdist:
     runs-on: ubuntu-latest
     needs: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,36 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "attribute-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0053e96dd3bec5b4879c23a138d6ef26f2cb936c9cdc96274ac2b9ed44b5bb54"
-dependencies = [
- "attribute-derive-macro",
- "derive-where",
- "manyhow",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "attribute-derive-macro"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463b53ad0fd5b460af4b1915fe045ff4d946d025fb6c4dc3337752eaa980f71b"
-dependencies = [
- "collection_literals",
- "interpolator",
- "manyhow",
- "proc-macro-utils",
- "proc-macro2",
- "quote",
- "quote-use",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,12 +140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "collection_literals"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,17 +157,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -227,29 +180,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "get-size-derive2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aac2af9f9a6a50e31b1e541d05b7925add83d3982c2793193fe9d4ee584323c"
-dependencies = [
- "attribute-derive",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "get-size2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a0312efd19e1c45922dfcc2d6806d3ffc4bca261f89f31fcc4f63f438d885"
-dependencies = [
- "compact_str",
- "get-size-derive2",
- "hashbrown",
- "smallvec",
-]
 
 [[package]]
 name = "getopts"
@@ -290,12 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "hashbrown"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,12 +236,6 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
-name = "interpolator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "is-macro"
@@ -369,29 +287,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "manyhow"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "memchr"
@@ -484,17 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-utils"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,28 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "quote-use"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
-dependencies = [
- "quote",
- "quote-use-macros",
-]
-
-[[package]]
-name = "quote-use-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -691,7 +553,6 @@ dependencies = [
  "aho-corasick",
  "bitflags",
  "compact_str",
- "get-size2",
  "is-macro",
  "itertools",
  "memchr",
@@ -709,7 +570,6 @@ dependencies = [
  "bitflags",
  "bstr",
  "compact_str",
- "get-size2",
  "memchr",
  "ruff_python_ast",
  "ruff_python_trivia",
@@ -742,9 +602,6 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-dependencies = [
- "get-size2",
-]
 
 [[package]]
 name = "rustc-hash"
@@ -802,12 +659,6 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "static_assertions"

--- a/rtest-core/src/pytest_executor.rs
+++ b/rtest-core/src/pytest_executor.rs
@@ -1,5 +1,6 @@
 //! Handles the execution of pytest with collected test nodes.
 
+use std::path::Path;
 use std::process::Command;
 
 /// Executes pytest with the given program, initial arguments, collected test nodes, and additional pytest arguments.
@@ -10,6 +11,7 @@ use std::process::Command;
 /// * `initial_args` - Initial arguments to pass to the program (e.g., `run` for `uv`).
 /// * `test_nodes` - A `Vec<String>` of test node IDs to execute.
 /// * `pytest_args` - Additional arguments to pass directly to pytest.
+/// * `working_dir` - Optional working directory for pytest execution.
 ///
 /// Exits the process with the pytest exit code.
 pub fn execute_tests(
@@ -17,11 +19,16 @@ pub fn execute_tests(
     initial_args: &[String],
     test_nodes: Vec<String>,
     pytest_args: Vec<String>,
+    working_dir: Option<&Path>,
 ) {
     let mut run_cmd = Command::new(program);
     run_cmd.args(initial_args);
     run_cmd.args(test_nodes);
     run_cmd.args(pytest_args);
+
+    if let Some(dir) = working_dir {
+        run_cmd.current_dir(dir);
+    }
 
     let run_status = run_cmd.status().expect("Failed to execute run command");
 

--- a/rtest-core/src/worker.rs
+++ b/rtest-core/src/worker.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
 
@@ -38,6 +39,7 @@ impl WorkerPool {
         initial_args: Vec<String>,
         tests: Vec<String>,
         pytest_args: Vec<String>,
+        working_dir: Option<PathBuf>,
     ) {
         let handle = thread::spawn(move || {
             let mut cmd = Command::new(&program);
@@ -55,6 +57,10 @@ impl WorkerPool {
             }
 
             cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+            if let Some(dir) = working_dir {
+                cmd.current_dir(dir);
+            }
 
             match cmd.output() {
                 Ok(output) => WorkerResult {

--- a/rtest-core/src/worker.rs
+++ b/rtest-core/src/worker.rs
@@ -48,6 +48,15 @@ impl WorkerPool {
                 cmd.arg(arg);
             }
 
+            // Add --rootdir to prevent pytest from traversing up the directory tree during
+            // its collection phase. Without this, pytest searches upward for config files
+            // and can hit protected Windows system directories like "C:\Documents and Settings",
+            // causing PermissionError even when we provide explicit test node IDs.
+            if let Some(ref dir) = working_dir {
+                cmd.arg("--rootdir");
+                cmd.arg(dir);
+            }
+
             for test in tests {
                 cmd.arg(test);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let runner = PytestRunner::new(args.env);
 
     let rootpath = env::current_dir().expect("Failed to get current directory");
-    let (test_nodes, errors) = match collect_tests_rust(rootpath, &[]) {
+    let (test_nodes, errors) = match collect_tests_rust(rootpath.clone(), &[]) {
         Ok((nodes, errors)) => (nodes, errors),
         Err(e) => {
             eprintln!("FATAL: {e}");
@@ -46,7 +46,13 @@ pub fn main() {
     }
 
     if worker_count == 1 {
-        execute_tests(&runner.program, &runner.initial_args, test_nodes, vec![]);
+        execute_tests(
+            &runner.program,
+            &runner.initial_args,
+            test_nodes,
+            vec![],
+            Some(&rootpath),
+        );
     } else {
         execute_tests_parallel(
             &runner.program,
@@ -54,6 +60,7 @@ pub fn main() {
             test_nodes,
             worker_count,
             &args.dist,
+            &rootpath,
         );
     }
 }
@@ -64,6 +71,7 @@ fn execute_tests_parallel(
     test_nodes: Vec<String>,
     worker_count: usize,
     dist_mode: &str,
+    rootpath: &std::path::Path,
 ) {
     println!("Running tests with {worker_count} workers using {dist_mode} distribution");
 
@@ -86,6 +94,7 @@ fn execute_tests_parallel(
                 initial_args.to_vec(),
                 tests,
                 vec![],
+                Some(rootpath.to_path_buf()),
             );
         }
     }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -15,9 +15,9 @@ fn test_cli_help() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Usage: rtest"));
-    assert!(stdout.contains("--package-manager"));
     assert!(stdout.contains("--env"));
-    assert!(!stdout.contains("--rust-collect")); // Should be removed
+    assert!(stdout.contains("--numprocesses"));
+    assert!(stdout.contains("--dist"));
 }
 
 /// Test that the CLI shows version when requested
@@ -33,10 +33,10 @@ fn test_cli_version() {
     assert!(stdout.contains("rtest"));
 }
 
-/// Test CLI argument parsing for different package managers
+/// Test CLI argument parsing for distribution modes
 #[test]
-fn test_package_manager_args() {
-    // Test with default (python)
+fn test_distribution_args() {
+    // Test with default (load)
     let output = Command::new("cargo")
         .args(["run", "--", "--help"])
         .output()
@@ -44,7 +44,7 @@ fn test_package_manager_args() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("[default: python]"));
+    assert!(stdout.contains("[default: load]"));
 }
 
 /// Test that invalid arguments are rejected


### PR DESCRIPTION
## Summary
- Add Windows 2022 and 2019 runners to CI testing matrix
- Add Windows wheel building to release workflow
- Ensures comprehensive Windows compatibility for the package

## Test plan
- [x] Verify CI runs successfully on Windows runners
- [ ] Confirm Windows wheels are built and published during releases