### PR TITLE
fix: resolve PyPI publishing and cross-compilation issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,8 @@ jobs:
         if: steps.check_release.outputs.new_release == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-x86_64
+          name: wheels-release-x86_64
           path: dist
-
-      - name: Publish to PyPI
-        if: steps.check_release.outputs.new_release == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   linux:
     runs-on: ${{ matrix.platform.runner }}
@@ -98,6 +92,8 @@ jobs:
           manylinux: auto
           before-script-linux: |
             if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
+              apt-get update
+              apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
               export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
               export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
@@ -106,13 +102,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}
           path: dist
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
 
   macos:
@@ -142,13 +133,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          name: wheels-macos-${{ matrix.platform.target }}
           path: dist
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -177,13 +163,8 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          name: wheels-windows-${{ matrix.platform.target }}
           path: dist
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   sdist:
     runs-on: ubuntu-latest
@@ -206,6 +187,17 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [release, linux, macos, windows, sdist]
+    if: needs.release.outputs.new_release == 'true'
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Fixed Linux aarch64 cross-compilation by installing required GCC toolchain
- Resolved PyPI publishing failures on macOS/Windows by consolidating to single Linux job
- Fixed artifact naming conflicts across different platform builds

## Test plan
- [ ] Verify aarch64 Linux builds complete successfully
- [ ] Confirm PyPI publishing works without platform restrictions
- [ ] Test that all platform wheels are properly uploaded and published