### PR TITLE
chore: remove Windows Server 2019 from CI matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,6 @@ jobs:
         platform:
           - runner: windows-2022
             target: x64
-          - runner: windows-2019
-            target: x64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Remove Windows Server 2019 runner from release workflow as it's being retired
- Keep Windows Server 2022 for Windows wheel builds

## Test plan
- [ ] Verify Windows builds still work on Server 2022
- [ ] Confirm no impact on wheel publishing