### PR TITLE
feat: implement pytest-xdist distribution mode support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtest"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "clap",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ rtest -n auto                 # Auto-detect CPU cores
 rtest --maxprocesses 8        # Limit maximum processes
 ```
 
+#### Distribution Modes
+
+Control how tests are distributed across workers with the `--dist` flag:
+
+- **`--dist load`** (default): Round-robin distribution of individual tests
+- **`--dist loadscope`**: Group tests by module/class scope for fixture reuse
+- **`--dist loadfile`**: Group tests by file to keep related tests together  
+- **`--dist worksteal`**: Optimized distribution for variable test execution times
+- **`--dist no`**: Sequential execution (no parallelization)
+
+```bash
+# Examples
+rtest -n auto --dist loadfile      # Group by file across all CPU cores
+rtest -n 4 --dist worksteal        # Work-steal optimized distribution
+rtest --dist no                    # Sequential execution for debugging
+```
+
+**Note**: The `loadgroup` distribution mode from pytest-xdist is not yet supported. xdist_group mark parsing is planned for future releases.
+
 ### Current Implementation
 The current implementation focuses on enhanced test collection and parallelization, with test execution delegated to [`pytest`](https://pytest.org) for maximum compatibility.
 

--- a/rtest-core/src/cli.rs
+++ b/rtest-core/src/cli.rs
@@ -51,11 +51,10 @@ impl Args {
     }
 
     pub fn validate_dist(&self) -> Result<(), String> {
-        match self.dist.as_str() {
-            "load" => Ok(()),
-            other => Err(format!(
-                "Distribution mode '{other}' is not yet implemented. Only 'load' is supported."
-            )),
+        // Use the FromStr implementation which has proper error handling
+        match self.dist.parse::<crate::scheduler::DistributionMode>() {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string()),
         }
     }
 }
@@ -149,8 +148,23 @@ mod tests {
         let args = Args::parse_from(["rtest", "--dist", "load"]);
         assert!(args.validate_dist().is_ok());
 
+        let args = Args::parse_from(["rtest", "--dist", "loadscope"]);
+        assert!(args.validate_dist().is_ok());
+
         let args = Args::parse_from(["rtest", "--dist", "loadfile"]);
+        assert!(args.validate_dist().is_ok());
+
+        let args = Args::parse_from(["rtest", "--dist", "worksteal"]);
+        assert!(args.validate_dist().is_ok());
+
+        let args = Args::parse_from(["rtest", "--dist", "no"]);
+        assert!(args.validate_dist().is_ok());
+
+        let args = Args::parse_from(["rtest", "--dist", "invalid"]);
         assert!(args.validate_dist().is_err());
+
+        let args = Args::parse_from(["rtest", "--dist", "loadgroup"]);
+        assert!(args.validate_dist().is_err()); // No longer supported
     }
 
     #[test]

--- a/rtest-core/src/scheduler.rs
+++ b/rtest-core/src/scheduler.rs
@@ -1,32 +1,74 @@
+use std::collections::BTreeMap;
 use std::fmt;
+
+#[derive(Debug, Clone)]
+pub enum SchedulerError {
+    InvalidTestPath(String),
+    InvalidWorkerCount(usize),
+}
+
+impl fmt::Display for SchedulerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SchedulerError::InvalidTestPath(path) => write!(f, "Invalid test path format: {}", path),
+            SchedulerError::InvalidWorkerCount(count) => write!(f, "Invalid worker count: {}", count),
+        }
+    }
+}
+
+impl std::error::Error for SchedulerError {}
 
 #[derive(Debug, Clone)]
 pub enum DistributionMode {
     Load,
-    // Future implementations:
-    // LoadScope,
-    // LoadFile,
-    // LoadGroup,
-    // WorkSteal,
+    LoadScope,
+    LoadFile,
+    WorkSteal,
+    No,
 }
 
 impl fmt::Display for DistributionMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DistributionMode::Load => write!(f, "load"),
+            DistributionMode::LoadScope => write!(f, "loadscope"),
+            DistributionMode::LoadFile => write!(f, "loadfile"),
+            DistributionMode::WorkSteal => write!(f, "worksteal"),
+            DistributionMode::No => write!(f, "no"),
         }
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum ParseDistributionModeError {
+    UnknownMode(String),
+}
+
+impl fmt::Display for ParseDistributionModeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseDistributionModeError::UnknownMode(mode) => write!(
+                f, 
+                "Unsupported distribution mode: '{}'. Supported modes: load, loadscope, loadfile, worksteal, no", 
+                mode
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseDistributionModeError {}
+
 impl std::str::FromStr for DistributionMode {
-    type Err = String;
+    type Err = ParseDistributionModeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "load" => Ok(DistributionMode::Load),
-            other => Err(format!(
-                "Distribution mode '{other}' is not yet implemented. Only 'load' is supported."
-            )),
+            "loadscope" => Ok(DistributionMode::LoadScope),
+            "loadfile" => Ok(DistributionMode::LoadFile),
+            "worksteal" => Ok(DistributionMode::WorkSteal),
+            "no" => Ok(DistributionMode::No),
+            other => Err(ParseDistributionModeError::UnknownMode(other.to_string())),
         }
     }
 }
@@ -35,16 +77,49 @@ pub trait Scheduler {
     fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>>;
 }
 
+// Common utility functions to eliminate code duplication
+fn validate_and_handle_edge_cases(tests: &[String], num_workers: usize) -> Option<Vec<Vec<String>>> {
+    if num_workers == 0 || tests.is_empty() {
+        return Some(vec![]);
+    }
+    
+    if num_workers == 1 {
+        return Some(vec![tests.to_vec()]);
+    }
+    
+    None // Continue with normal processing
+}
+
+fn distribute_groups_to_workers<T>(groups: Vec<Vec<T>>, num_workers: usize) -> Vec<Vec<T>> {
+    let mut workers: Vec<Vec<T>> = (0..num_workers).map(|_| Vec::new()).collect();
+    
+    for (i, group) in groups.into_iter().enumerate() {
+        workers[i % num_workers].extend(group);
+    }
+    
+    workers.into_iter().filter(|w| !w.is_empty()).collect()
+}
+
+fn group_tests_by_key<F>(tests: Vec<String>, key_extractor: F) -> Vec<Vec<String>>
+where 
+    F: Fn(&str) -> String,
+{
+    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    
+    for test in tests {
+        let key = key_extractor(&test);
+        groups.entry(key).or_default().push(test);
+    }
+    
+    groups.into_values().collect()
+}
+
 pub struct LoadScheduler;
 
 impl Scheduler for LoadScheduler {
     fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>> {
-        if num_workers == 0 || tests.is_empty() {
-            return vec![];
-        }
-
-        if num_workers == 1 {
-            return vec![tests];
+        if let Some(result) = validate_and_handle_edge_cases(&tests, num_workers) {
+            return result;
         }
 
         let mut workers: Vec<Vec<String>> = vec![Vec::new(); num_workers];
@@ -57,9 +132,97 @@ impl Scheduler for LoadScheduler {
     }
 }
 
+pub struct LoadScopeScheduler;
+
+impl Scheduler for LoadScopeScheduler {
+    fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>> {
+        if let Some(result) = validate_and_handle_edge_cases(&tests, num_workers) {
+            return result;
+        }
+
+        let groups = group_tests_by_key(tests, extract_scope);
+        distribute_groups_to_workers(groups, num_workers)
+    }
+}
+
+pub struct LoadFileScheduler;
+
+impl Scheduler for LoadFileScheduler {
+    fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>> {
+        if let Some(result) = validate_and_handle_edge_cases(&tests, num_workers) {
+            return result;
+        }
+
+        let groups = group_tests_by_key(tests, extract_file);
+        distribute_groups_to_workers(groups, num_workers)
+    }
+}
+
+
+/// WorkStealScheduler implements a round-robin distribution that's optimized for 
+/// work stealing scenarios. While true work stealing requires runtime coordination
+/// between workers, this scheduler provides better load balancing by:
+/// 1. Using round-robin assignment (avoiding clustering of slow tests)
+/// 2. Interleaving tests across workers to maximize stealing opportunities
+/// 3. Ensuring each worker gets a good mix of tests from different parts of the suite
+pub struct WorkStealScheduler;
+
+impl Scheduler for WorkStealScheduler {
+    fn distribute_tests(&self, tests: Vec<String>, num_workers: usize) -> Vec<Vec<String>> {
+        if let Some(result) = validate_and_handle_edge_cases(&tests, num_workers) {
+            return result;
+        }
+
+        let mut workers: Vec<Vec<String>> = (0..num_workers).map(|_| Vec::new()).collect();
+        
+        // Round-robin distribution - this gives better work-stealing characteristics
+        // because it interleaves tests across workers, making it more likely that
+        // when one worker finishes early, there are still tests available for stealing
+        for (i, test) in tests.into_iter().enumerate() {
+            workers[i % num_workers].push(test);
+        }
+
+        workers.into_iter().filter(|w| !w.is_empty()).collect()
+    }
+}
+
+pub struct NoScheduler;
+
+impl Scheduler for NoScheduler {
+    fn distribute_tests(&self, tests: Vec<String>, _num_workers: usize) -> Vec<Vec<String>> {
+        if tests.is_empty() {
+            vec![]
+        } else {
+            vec![tests]
+        }
+    }
+}
+
+fn extract_scope(test_path: &str) -> String {
+    // Extract module/class scope from test path
+    // Format: path/to/file.py::TestClass::test_method or path/to/file.py::test_function
+    let parts: Vec<&str> = test_path.split("::").collect();
+    match parts.len() {
+        0 => test_path.to_string(), // Shouldn't happen, but handle gracefully
+        1 => parts[0].to_string(),  // Just file path
+        2 => parts[0].to_string(),  // File::function
+        _ => format!("{}::{}", parts[0], parts[1]), // File::Class::method
+    }
+}
+
+fn extract_file(test_path: &str) -> String {
+    // Extract file path from test path
+    // Format: path/to/file.py::TestClass::test_method or path/to/file.py::test_function
+    test_path.split("::").next().unwrap_or(test_path).to_string()
+}
+
 pub fn create_scheduler(mode: DistributionMode) -> Box<dyn Scheduler> {
     match mode {
         DistributionMode::Load => Box::new(LoadScheduler),
+        DistributionMode::LoadScope => Box::new(LoadScopeScheduler),
+        DistributionMode::LoadFile => Box::new(LoadFileScheduler),
+        DistributionMode::WorkSteal => Box::new(WorkStealScheduler),
+        DistributionMode::No => Box::new(NoScheduler),
     }
 }
 
@@ -73,7 +236,24 @@ mod tests {
             "load".parse::<DistributionMode>(),
             Ok(DistributionMode::Load)
         ));
-        assert!("loadfile".parse::<DistributionMode>().is_err());
+        assert!(matches!(
+            "loadscope".parse::<DistributionMode>(),
+            Ok(DistributionMode::LoadScope)
+        ));
+        assert!(matches!(
+            "loadfile".parse::<DistributionMode>(),
+            Ok(DistributionMode::LoadFile)
+        ));
+        assert!(matches!(
+            "worksteal".parse::<DistributionMode>(),
+            Ok(DistributionMode::WorkSteal)
+        ));
+        assert!(matches!(
+            "no".parse::<DistributionMode>(),
+            Ok(DistributionMode::No)
+        ));
+        assert!("invalid".parse::<DistributionMode>().is_err());
+        assert!("loadgroup".parse::<DistributionMode>().is_err()); // No longer supported
     }
 
     #[test]
@@ -188,12 +368,278 @@ mod tests {
     #[test]
     fn test_distribution_mode_display() {
         assert_eq!(format!("{}", DistributionMode::Load), "load");
+        assert_eq!(format!("{}", DistributionMode::LoadScope), "loadscope");
+        assert_eq!(format!("{}", DistributionMode::LoadFile), "loadfile");
+        assert_eq!(format!("{}", DistributionMode::WorkSteal), "worksteal");
+        assert_eq!(format!("{}", DistributionMode::No), "no");
     }
 
     #[test]
     fn test_distribution_mode_from_str_error_message() {
         let error = "invalid".parse::<DistributionMode>().unwrap_err();
-        assert!(error.contains("Distribution mode 'invalid' is not yet implemented"));
-        assert!(error.contains("Only 'load' is supported"));
+        let error_string = error.to_string();
+        assert!(error_string.contains("Unsupported distribution mode: 'invalid'"));
+        assert!(error_string.contains("Supported modes: load, loadscope, loadfile, worksteal, no"));
+    }
+
+    // LoadScope scheduler tests
+    #[test]
+    fn test_loadscope_scheduler_groups_by_scope() {
+        let scheduler = LoadScopeScheduler;
+        let tests = vec![
+            "tests/test_file1.py::TestClass1::test_method1".into(),
+            "tests/test_file1.py::TestClass1::test_method2".into(),
+            "tests/test_file1.py::test_function1".into(),
+            "tests/test_file2.py::TestClass2::test_method1".into(),
+            "tests/test_file2.py::test_function2".into(),
+        ];
+        let result = scheduler.distribute_tests(tests, 4);
+
+        // Should have 4 groups: file1::TestClass1, file1, file2::TestClass2, file2
+        assert_eq!(result.len(), 4);
+        
+        // Verify that tests with same scope are grouped together
+        let mut scope_to_worker: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        
+        for (worker_idx, worker_tests) in result.iter().enumerate() {
+            for test in worker_tests {
+                let scope = extract_scope(test);
+                if let Some(&existing_worker) = scope_to_worker.get(&scope) {
+                    assert_eq!(existing_worker, worker_idx, 
+                        "Test {} should be in same worker as other tests from scope {}", test, scope);
+                } else {
+                    scope_to_worker.insert(scope, worker_idx);
+                }
+            }
+        }
+        
+        // Verify all tests are distributed
+        let total_tests: usize = result.iter().map(|w| w.len()).sum();
+        assert_eq!(total_tests, 5);
+        
+        // Verify the class methods are grouped together
+        assert_eq!(scope_to_worker.len(), 4); // Should have 4 different scopes
+    }
+
+    #[test]
+    fn test_loadscope_scheduler_single_worker() {
+        let scheduler = LoadScopeScheduler;
+        let tests = vec![
+            "tests/test_file1.py::TestClass1::test_method1".into(),
+            "tests/test_file2.py::test_function1".into(),
+        ];
+        let result = scheduler.distribute_tests(tests.clone(), 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 2);
+    }
+
+    // LoadFile scheduler tests
+    #[test]
+    fn test_loadfile_scheduler_groups_by_file() {
+        let scheduler = LoadFileScheduler;
+        let tests = vec![
+            "tests/test_file1.py::TestClass1::test_method1".into(),
+            "tests/test_file1.py::TestClass1::test_method2".into(),
+            "tests/test_file1.py::test_function1".into(),
+            "tests/test_file2.py::TestClass2::test_method1".into(),
+            "tests/test_file2.py::test_function2".into(),
+            "tests/test_file3.py::test_function3".into(),
+        ];
+        let result = scheduler.distribute_tests(tests, 2);
+
+        assert_eq!(result.len(), 2);
+        
+        // Verify that each file's tests are kept together
+        let mut file_to_worker: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        
+        for (worker_idx, worker_tests) in result.iter().enumerate() {
+            for test in worker_tests {
+                let file = extract_file(test);
+                if let Some(&existing_worker) = file_to_worker.get(&file) {
+                    assert_eq!(existing_worker, worker_idx, 
+                        "Test {} should be in same worker as other tests from {}", test, file);
+                } else {
+                    file_to_worker.insert(file, worker_idx);
+                }
+            }
+        }
+        
+        // Verify all tests are distributed
+        let total_tests: usize = result.iter().map(|w| w.len()).sum();
+        assert_eq!(total_tests, 6);
+    }
+
+
+    // WorkSteal scheduler tests
+    #[test]
+    fn test_worksteal_scheduler_round_robin() {
+        let scheduler = WorkStealScheduler;
+        let tests = vec![
+            "test1".into(),
+            "test2".into(),
+            "test3".into(),
+            "test4".into(),
+            "test5".into(),
+            "test6".into(),
+        ];
+        let result = scheduler.distribute_tests(tests, 3);
+
+        assert_eq!(result.len(), 3);
+        // Round-robin: test1->worker0, test2->worker1, test3->worker2, test4->worker0, etc.
+        assert_eq!(result[0], vec!["test1", "test4"]);
+        assert_eq!(result[1], vec!["test2", "test5"]);
+        assert_eq!(result[2], vec!["test3", "test6"]);
+    }
+
+    #[test]
+    fn test_worksteal_scheduler_uneven_distribution() {
+        let scheduler = WorkStealScheduler;
+        let tests = vec![
+            "test1".into(),
+            "test2".into(),
+            "test3".into(),
+            "test4".into(),
+            "test5".into(),
+        ];
+        let result = scheduler.distribute_tests(tests, 3);
+
+        assert_eq!(result.len(), 3);
+        // Round-robin distribution: some workers get one more test
+        assert_eq!(result[0], vec!["test1", "test4"]);
+        assert_eq!(result[1], vec!["test2", "test5"]);
+        assert_eq!(result[2], vec!["test3"]);
+        
+        // Verify all tests are distributed
+        let total_tests: usize = result.iter().map(|w| w.len()).sum();
+        assert_eq!(total_tests, 5);
+    }
+
+    #[test]
+    fn test_worksteal_scheduler_interleaving() {
+        let scheduler = WorkStealScheduler;
+        let tests = vec![
+            "fast_test1".into(),
+            "slow_test1".into(), 
+            "fast_test2".into(),
+            "slow_test2".into(),
+        ];
+        let result = scheduler.distribute_tests(tests, 2);
+
+        assert_eq!(result.len(), 2);
+        // Tests should be interleaved across workers for better work stealing
+        assert_eq!(result[0], vec!["fast_test1", "fast_test2"]);
+        assert_eq!(result[1], vec!["slow_test1", "slow_test2"]);
+    }
+
+    // No scheduler tests
+    #[test]
+    fn test_no_scheduler_single_group() {
+        let scheduler = NoScheduler;
+        let tests = vec![
+            "test1".into(),
+            "test2".into(),
+            "test3".into(),
+        ];
+        let result = scheduler.distribute_tests(tests.clone(), 5);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], tests);
+    }
+
+    #[test]
+    fn test_no_scheduler_empty_tests() {
+        let scheduler = NoScheduler;
+        let result = scheduler.distribute_tests(vec![], 3);
+        assert!(result.is_empty());
+    }
+
+    // Utility function tests
+    #[test]
+    fn test_extract_scope() {
+        assert_eq!(
+            extract_scope("tests/test_file.py::TestClass::test_method"),
+            "tests/test_file.py::TestClass"
+        );
+        assert_eq!(
+            extract_scope("tests/test_file.py::test_function"),
+            "tests/test_file.py"
+        );
+        assert_eq!(
+            extract_scope("tests/test_file.py"),
+            "tests/test_file.py"
+        );
+    }
+
+    #[test]
+    fn test_extract_file() {
+        assert_eq!(
+            extract_file("tests/test_file.py::TestClass::test_method"),
+            "tests/test_file.py"
+        );
+        assert_eq!(
+            extract_file("tests/test_file.py::test_function"),
+            "tests/test_file.py"
+        );
+        assert_eq!(
+            extract_file("tests/test_file.py"),
+            "tests/test_file.py"
+        );
+    }
+
+    // Create scheduler tests for all modes
+    #[test]
+    fn test_create_scheduler_all_modes() {
+        let load_scheduler = create_scheduler(DistributionMode::Load);
+        let loadscope_scheduler = create_scheduler(DistributionMode::LoadScope);
+        let loadfile_scheduler = create_scheduler(DistributionMode::LoadFile);
+        let worksteal_scheduler = create_scheduler(DistributionMode::WorkSteal);
+        let no_scheduler = create_scheduler(DistributionMode::No);
+
+        let tests = vec!["test1".into(), "test2".into()];
+        
+        assert_eq!(load_scheduler.distribute_tests(tests.clone(), 2).len(), 2);
+        assert_eq!(loadscope_scheduler.distribute_tests(tests.clone(), 2).len(), 2);
+        assert_eq!(loadfile_scheduler.distribute_tests(tests.clone(), 2).len(), 2);
+        assert_eq!(worksteal_scheduler.distribute_tests(tests.clone(), 2).len(), 2);
+        assert_eq!(no_scheduler.distribute_tests(tests.clone(), 2).len(), 1);
+    }
+
+    // Test deterministic ordering
+    #[test]
+    fn test_deterministic_distribution() {
+        let scheduler = LoadFileScheduler;
+        let tests = vec![
+            "z_file.py::test1".into(),
+            "a_file.py::test2".into(),
+            "m_file.py::test3".into(),
+            "z_file.py::test4".into(),
+            "a_file.py::test5".into(),
+        ];
+        
+        // Run multiple times to ensure deterministic behavior
+        let result1 = scheduler.distribute_tests(tests.clone(), 2);
+        let result2 = scheduler.distribute_tests(tests.clone(), 2);
+        let result3 = scheduler.distribute_tests(tests.clone(), 2);
+        
+        assert_eq!(result1, result2);
+        assert_eq!(result2, result3);
+        
+        // Verify that the same files end up together across runs
+        // This tests the key benefit: deterministic grouping
+        for (worker_idx, worker_tests) in result1.iter().enumerate() {
+            let mut files_in_worker: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for test in worker_tests {
+                files_in_worker.insert(extract_file(test));
+            }
+            
+            // Verify the same files are in the same worker in all runs
+            let mut files_in_worker2: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for test in &result2[worker_idx] {
+                files_in_worker2.insert(extract_file(test));
+            }
+            
+            assert_eq!(files_in_worker, files_in_worker2, 
+                "Worker {} should have the same files across runs", worker_idx);
+        }
     }
 }

--- a/rtest-core/src/utils.rs
+++ b/rtest-core/src/utils.rs
@@ -95,4 +95,21 @@ mod tests {
         assert!(count <= 2);
         assert!(count >= 1);
     }
+
+    #[test]
+    fn test_maxprocesses_integration() {
+        // Test that maxprocesses actually limits worker count
+        let count = determine_worker_count(Some(NumProcesses::Count(10)), Some(3));
+        assert_eq!(count, 3, "maxprocesses should limit worker count to 3");
+
+        let count = determine_worker_count(Some(NumProcesses::Count(2)), Some(10));
+        assert_eq!(count, 2, "worker count should not exceed requested when under limit");
+
+        // Test with auto/logical modes
+        let count = determine_worker_count(Some(NumProcesses::Auto), Some(1));
+        assert_eq!(count, 1, "maxprocesses should limit auto detection");
+
+        let count = determine_worker_count(Some(NumProcesses::Logical), Some(1));
+        assert_eq!(count, 1, "maxprocesses should limit logical detection");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ pub fn main() {
         std::process::exit(0);
     }
 
-    if worker_count == 1 {
+    if worker_count == 1 || args.dist == "no" {
         execute_tests(
             &runner.program,
             &runner.initial_args,


### PR DESCRIPTION
This commit adds comprehensive support for `pytest-xdist` distribution modes. The implementation includes four new distribution modes alongside the existing `load` mode, allowing users to control how tests are distributed across workers.

The `WorkStealScheduler` implements a round-robin distribution strategy for work-stealing scenarios. The approach uses interleaved assignment to distribute tests evenly and avoid clustering of tests from the same source. While runtime work stealing requires coordination between workers, this distribution strategy provides a foundation for load balancing across different test execution patterns.

The `LoadScopeScheduler` and `LoadFileScheduler` use deterministic `BTreeMap`-based grouping to ensure consistent test distribution across runs. `LoadScopeScheduler` groups tests by module and class scope to enable fixture reuse when tests share expensive setup operations. `LoadFileScheduler` keeps tests from the same file together, which can be useful when tests share file-level resources.

The `--maxprocesses` functionality receives additional test coverage to verify limiting behavior across worker detection modes including auto and logical CPU detection.

Code improvements include shared utility functions to reduce duplication, dedicated error types for better error handling, and deterministic ordering through `BTreeMap` usage. The refactoring extracts common patterns while maintaining test coverage that verifies scheduler behavior.