### PR TITLE
Fix subproject handling and respect pyproject.toml testpaths configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +312,16 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indoc"
@@ -663,7 +679,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtest"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "clap",
  "pyo3",
@@ -682,6 +698,7 @@ dependencies = [
  "regex",
  "ruff_python_ast",
  "ruff_python_parser",
+ "toml",
 ]
 
 [[package]]
@@ -798,6 +815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +911,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -1028,6 +1095,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/rtest-core/Cargo.toml
+++ b/rtest-core/Cargo.toml
@@ -11,6 +11,7 @@ ruff_python_parser = { path = "../ruff/crates/ruff_python_parser" }
 ruff_python_ast = { path = "../ruff/crates/ruff_python_ast" }
 num_cpus = "1.0"
 log = "0.4"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rtest-core/src/config.rs
+++ b/rtest-core/src/config.rs
@@ -1,0 +1,113 @@
+//! Configuration parsing for pytest settings from pyproject.toml
+
+use log::debug;
+use std::path::{Path, PathBuf};
+use toml::Value;
+
+/// Pytest configuration from pyproject.toml
+#[derive(Debug, Clone)]
+pub struct PytestConfig {
+    /// Test paths to search for tests
+    pub testpaths: Vec<PathBuf>,
+}
+
+impl Default for PytestConfig {
+    fn default() -> Self {
+        Self {
+            testpaths: vec![],
+        }
+    }
+}
+
+/// Read pytest configuration from pyproject.toml
+pub fn read_pytest_config(root_path: &Path) -> PytestConfig {
+    let pyproject_path = root_path.join("pyproject.toml");
+    
+    if !pyproject_path.exists() {
+        debug!("No pyproject.toml found at {:?}", pyproject_path);
+        return PytestConfig::default();
+    }
+    
+    let content = match std::fs::read_to_string(&pyproject_path) {
+        Ok(content) => content,
+        Err(e) => {
+            debug!("Failed to read pyproject.toml: {}", e);
+            return PytestConfig::default();
+        }
+    };
+    
+    let toml_value: Value = match toml::from_str(&content) {
+        Ok(value) => value,
+        Err(e) => {
+            debug!("Failed to parse pyproject.toml: {}", e);
+            return PytestConfig::default();
+        }
+    };
+    
+    let mut config = PytestConfig::default();
+    
+    if let Some(testpaths) = toml_value
+        .get("tool")
+        .and_then(|t| t.get("pytest"))
+        .and_then(|p| p.get("ini_options"))
+        .and_then(|i| i.get("testpaths"))
+        .and_then(|t| t.as_array())
+    {
+        config.testpaths = testpaths
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(PathBuf::from)
+            .collect();
+        debug!("Found testpaths in pyproject.toml: {:?}", config.testpaths);
+    }
+    
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+    
+    #[test]
+    fn test_read_pytest_config_with_testpaths() {
+        let temp_dir = TempDir::new().unwrap();
+        let pyproject_path = temp_dir.path().join("pyproject.toml");
+        
+        let content = r#"
+[tool.pytest.ini_options]
+testpaths = ["tests", "test"]
+"#;
+        
+        fs::write(&pyproject_path, content).unwrap();
+        
+        let config = read_pytest_config(temp_dir.path());
+        assert_eq!(config.testpaths.len(), 2);
+        assert_eq!(config.testpaths[0], PathBuf::from("tests"));
+        assert_eq!(config.testpaths[1], PathBuf::from("test"));
+    }
+    
+    #[test]
+    fn test_read_pytest_config_no_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = read_pytest_config(temp_dir.path());
+        assert!(config.testpaths.is_empty());
+    }
+    
+    #[test]
+    fn test_read_pytest_config_no_testpaths() {
+        let temp_dir = TempDir::new().unwrap();
+        let pyproject_path = temp_dir.path().join("pyproject.toml");
+        
+        let content = r#"
+[tool.pytest.ini_options]
+filterwarnings = ["error"]
+"#;
+        
+        fs::write(&pyproject_path, content).unwrap();
+        
+        let config = read_pytest_config(temp_dir.path());
+        assert!(config.testpaths.is_empty());
+    }
+}

--- a/rtest-core/src/lib.rs
+++ b/rtest-core/src/lib.rs
@@ -3,10 +3,12 @@
 pub mod cli;
 pub mod collection;
 pub mod collection_integration;
+pub mod config;
 pub mod pytest_executor;
 pub mod python_discovery;
 pub mod runner;
 pub mod scheduler;
+pub mod subproject;
 pub mod utils;
 pub mod worker;
 

--- a/rtest-core/src/pytest_executor.rs
+++ b/rtest-core/src/pytest_executor.rs
@@ -13,29 +13,23 @@ use std::process::Command;
 /// * `pytest_args` - Additional arguments to pass directly to pytest.
 /// * `working_dir` - Optional working directory for pytest execution.
 ///
-/// Exits the process with the pytest exit code.
+/// Returns the exit code from pytest.
 pub fn execute_tests(
     program: &str,
     initial_args: &[String],
     test_nodes: Vec<String>,
     pytest_args: Vec<String>,
     working_dir: Option<&Path>,
-) {
+) -> i32 {
     let mut run_cmd = Command::new(program);
     run_cmd.args(initial_args);
 
-    // Set working directory and constrain pytest's collection scope
     if let Some(dir) = working_dir {
         run_cmd.current_dir(dir);
-        // Add --rootdir to prevent pytest from traversing up the directory tree during
-        // its collection phase. Without this, pytest searches upward for config files
-        // and can hit protected Windows system directories like "C:\Documents and Settings",
-        // causing PermissionError even when we provide explicit test node IDs.
         run_cmd.arg("--rootdir");
         run_cmd.arg(dir);
     }
 
-    // Add test nodes after rootdir
     run_cmd.args(test_nodes);
     run_cmd.args(pytest_args);
 
@@ -43,9 +37,10 @@ pub fn execute_tests(
         Ok(status) => status,
         Err(e) => {
             eprintln!("Failed to execute pytest command: {}", e);
-            std::process::exit(1);
+            return 1;
         }
     };
 
-    std::process::exit(run_status.code().unwrap_or(1));
+    run_status.code().unwrap_or(1)
 }
+

--- a/rtest-core/src/subproject.rs
+++ b/rtest-core/src/subproject.rs
@@ -1,0 +1,123 @@
+//! Subproject detection and test grouping functionality.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+
+/// Splits a test node ID into file path and test parts
+fn split_test_node(node: &str) -> (&str, Option<&str>) {
+    match node.split_once("::") {
+        Some((path, test)) => (path, Some(test)),
+        None => (node, None),
+    }
+}
+
+/// Groups test nodes by their subproject
+pub fn group_tests_by_subproject(
+    rootpath: &Path,
+    test_nodes: &[String],
+) -> HashMap<PathBuf, Vec<String>> {
+    let mut groups: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    let mut subproject_roots: HashSet<PathBuf> = HashSet::new();
+    
+    for test_node in test_nodes {
+        let subproject_root = find_subproject_root(rootpath, test_node);
+        let is_subproject = subproject_root != *rootpath;
+        
+        if is_subproject {
+            subproject_roots.insert(subproject_root.clone());
+        }
+        
+        groups.entry(subproject_root).or_default().push(test_node.clone());
+    }
+    
+    if let Some(root_tests) = groups.get_mut(rootpath) {
+        root_tests.retain(|test_node| {
+            let (file_path, _) = split_test_node(test_node);
+            let test_path = rootpath.join(file_path);
+            
+            !subproject_roots.iter().any(|subproject| {
+                test_path.starts_with(subproject)
+            })
+        });
+    }
+    
+    groups
+}
+
+fn find_subproject_root(rootpath: &Path, test_node: &str) -> PathBuf {
+    let (file_path, _) = split_test_node(test_node);
+    let test_path = rootpath.join(file_path);
+    
+    // Ensure the test path is within the root path
+    let test_path = match test_path.canonicalize() {
+        Ok(path) if path.starts_with(rootpath) => path,
+        _ => return rootpath.to_path_buf(),
+    };
+    
+    if let Some(parent) = test_path.parent() {
+        let mut current = parent;
+        
+        while current.starts_with(rootpath) && current != rootpath {
+            if current.join("pyproject.toml").exists() {
+                return current.to_path_buf();
+            }
+            
+            match current.parent() {
+                Some(parent) => current = parent,
+                None => break,
+            }
+        }
+    }
+    
+    rootpath.to_path_buf()
+}
+
+pub fn make_test_paths_relative(
+    test_nodes: &[String],
+    old_base: &Path,
+    new_base: &Path,
+) -> Vec<String> {
+    test_nodes
+        .iter()
+        .map(|node| {
+            let (file_path, test_part) = split_test_node(node);
+            
+            let absolute_path = old_base.join(file_path);
+            match absolute_path.strip_prefix(new_base) {
+                Ok(relative_path) => {
+                    let mut new_node = relative_path.to_string_lossy().into_owned();
+                    if let Some(test) = test_part {
+                        new_node.push_str("::");
+                        new_node.push_str(test);
+                    }
+                    new_node
+                }
+                Err(_) => node.clone(),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_make_test_paths_relative() {
+        let test_nodes = vec![
+            "examples/tutorial/tests/test_auth.py::test_register".to_string(),
+            "examples/tutorial/tests/test_auth.py::TestAuth::test_login".to_string(),
+            "tests/test_basic.py::test_simple".to_string(),
+        ];
+        
+        let old_base = Path::new("/Users/test/flask");
+        let new_base = Path::new("/Users/test/flask/examples/tutorial");
+        
+        let result = make_test_paths_relative(&test_nodes, old_base, new_base);
+        
+        assert_eq!(result[0], "tests/test_auth.py::test_register");
+        assert_eq!(result[1], "tests/test_auth.py::TestAuth::test_login");
+        assert_eq!(result[2], "tests/test_basic.py::test_simple");
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "rtest"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
This commit addresses two issues:

1. Subproject Detection and Execution:
   - Added automatic detection of subprojects with their own pyproject.toml files
   - Tests are now grouped by subproject and executed with the appropriate working directory
   - This fixes import errors when tests require packages installed in subproject directories
   - Prevents duplicate test execution by filtering tests that belong to subprojects

2. Respect pytest's testpaths Configuration:
   - rtest now reads and respects the `tool.pytest.ini_options.testpaths` setting from pyproject.toml
   - When no explicit paths are provided, only configured test directories are searched
   - This aligns rtest's behavior with pytest's default configuration