### PR TITLE
refactor: split collection module into focused submodules

### DIFF
--- a/rtest-core/src/collection/config.rs
+++ b/rtest-core/src/collection/config.rs
@@ -1,0 +1,40 @@
+//! Collection configuration.
+
+use std::path::PathBuf;
+
+/// Configuration for collection
+#[derive(Debug, Clone)]
+pub struct CollectionConfig {
+    pub ignore_patterns: Vec<String>,
+    #[allow(dead_code)]
+    pub ignore_glob_patterns: Vec<String>,
+    pub norecursedirs: Vec<String>,
+    pub testpaths: Vec<PathBuf>,
+    pub python_files: Vec<String>,
+    pub python_classes: Vec<String>,
+    pub python_functions: Vec<String>,
+}
+
+impl Default for CollectionConfig {
+    fn default() -> Self {
+        Self {
+            ignore_patterns: vec![],
+            ignore_glob_patterns: vec![],
+            norecursedirs: vec![
+                "*.egg".into(),
+                ".*".into(),
+                "_darcs".into(),
+                "build".into(),
+                "CVS".into(),
+                "dist".into(),
+                "node_modules".into(),
+                "venv".into(),
+                "{arch}".into(),
+            ],
+            testpaths: vec![],
+            python_files: vec!["test_*.py".into(), "*_test.py".into()],
+            python_classes: vec!["Test*".into()],
+            python_functions: vec!["test*".into()],
+        }
+    }
+}

--- a/rtest-core/src/collection/error.rs
+++ b/rtest-core/src/collection/error.rs
@@ -1,0 +1,44 @@
+//! Collection error types.
+
+use std::fmt;
+
+/// Result type for collection operations
+pub type CollectionResult<T> = Result<T, CollectionError>;
+
+/// Collection-specific errors
+#[derive(Debug)]
+#[allow(dead_code, clippy::enum_variant_names)]
+pub enum CollectionError {
+    IoError(std::io::Error),
+    ParseError(String),
+    ImportError(String),
+    SkipError(String),
+}
+
+impl fmt::Display for CollectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IoError(e) => write!(f, "IO error: {e}"),
+            Self::ParseError(e) => write!(f, "Parse error: {e}"),
+            Self::ImportError(e) => write!(f, "Import error: {e}"),
+            Self::SkipError(e) => write!(f, "Skip: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CollectionError {}
+
+impl From<std::io::Error> for CollectionError {
+    fn from(err: std::io::Error) -> Self {
+        CollectionError::IoError(err)
+    }
+}
+
+/// Outcome of a collection operation
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum CollectionOutcome {
+    Passed,
+    Failed,
+    Skipped,
+}

--- a/rtest-core/src/collection/mod.rs
+++ b/rtest-core/src/collection/mod.rs
@@ -1,0 +1,9 @@
+//! Pytest collection implementation.
+//!
+//! This module provides a modular implementation of pytest's collection logic.
+
+pub mod config;
+pub mod error;
+pub mod nodes;
+pub mod types;
+mod utils;

--- a/rtest-core/src/collection/types.rs
+++ b/rtest-core/src/collection/types.rs
@@ -1,0 +1,35 @@
+//! Collection types and traits.
+
+use super::error::CollectionResult;
+use std::path::{Path, PathBuf};
+
+/// Location information for a test item
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Location {
+    pub path: PathBuf,
+    pub line: Option<usize>,
+    pub name: String,
+}
+
+/// Base trait for all collectible nodes
+pub trait Collector: std::fmt::Debug {
+    /// Unique identifier for this node
+    fn nodeid(&self) -> &str;
+
+    /// Parent collector, if any
+    #[allow(dead_code)]
+    fn parent(&self) -> Option<&dyn Collector>;
+
+    /// Collect child nodes
+    fn collect(&self) -> CollectionResult<Vec<Box<dyn Collector>>>;
+
+    /// Get the path associated with this collector
+    #[allow(dead_code)]
+    fn path(&self) -> &Path;
+
+    /// Check if this is a test item (leaf node)
+    fn is_item(&self) -> bool {
+        false
+    }
+}

--- a/rtest-core/src/collection/utils.rs
+++ b/rtest-core/src/collection/utils.rs
@@ -1,0 +1,23 @@
+//! Collection utility functions.
+
+/// Simple glob pattern matching
+pub fn glob_match(pattern: &str, text: &str) -> bool {
+    use glob::Pattern;
+
+    // Try to use the glob crate for more accurate matching
+    if let Ok(glob_pattern) = Pattern::new(pattern) {
+        glob_pattern.matches(text)
+    } else {
+        // Fallback to simple matching
+        if pattern.starts_with('*') && pattern.ends_with('*') {
+            let middle = &pattern[1..pattern.len() - 1];
+            text.contains(middle)
+        } else if let Some(suffix) = pattern.strip_prefix('*') {
+            text.ends_with(suffix)
+        } else if let Some(prefix) = pattern.strip_suffix('*') {
+            text.starts_with(prefix)
+        } else {
+            pattern == text
+        }
+    }
+}

--- a/rtest-core/src/collection_integration.rs
+++ b/rtest-core/src/collection_integration.rs
@@ -1,6 +1,8 @@
 //! Integration between Rust collection and pytest execution.
 
-use crate::collection::{collect_one_node, CollectionError, Collector, Session};
+use crate::collection::error::{CollectionError, CollectionOutcome};
+use crate::collection::nodes::{collect_one_node, Session};
+use crate::collection::types::Collector;
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -47,12 +49,12 @@ fn collect_items_recursive(
     } else {
         let report = collect_one_node(collector);
         match report.outcome {
-            crate::collection::CollectionOutcome::Passed => {
+            CollectionOutcome::Passed => {
                 for child in report.result {
                     collect_items_recursive(child.as_ref(), test_nodes, collection_errors);
                 }
             }
-            crate::collection::CollectionOutcome::Failed => {
+            CollectionOutcome::Failed => {
                 if let Some(error) = report.error_type {
                     collection_errors
                         .errors

--- a/rtest-core/src/lib.rs
+++ b/rtest-core/src/lib.rs
@@ -12,7 +12,7 @@ pub mod subproject;
 pub mod utils;
 pub mod worker;
 
-pub use collection::{CollectionError, CollectionResult};
+pub use collection::error::{CollectionError, CollectionResult};
 pub use collection_integration::{collect_tests_rust, display_collection_results};
 pub use pytest_executor::execute_tests;
 pub use runner::PytestRunner;

--- a/rtest-core/src/python_discovery/discovery.rs
+++ b/rtest-core/src/python_discovery/discovery.rs
@@ -1,6 +1,8 @@
 //! Test discovery types and main entry point.
 
-use crate::collection::{CollectionError, CollectionResult, Function, Location};
+use crate::collection::error::{CollectionError, CollectionResult};
+use crate::collection::nodes::Function;
+use crate::collection::types::Location;
 use crate::python_discovery::visitor::TestDiscoveryVisitor;
 use ruff_python_ast::Mod;
 use ruff_python_parser::{parse, Mode, ParseOptions};


### PR DESCRIPTION
Split the collection module into logical submodules for better maintainability and clarity:

- collection/error.rs: Error types and collection outcomes
- collection/types.rs: Core traits and types (Collector trait, Location)
- collection/config.rs: Collection configuration
- collection/nodes.rs: Node implementations (Session, Directory, Module, Function)
- collection/utils.rs: Utility functions (glob matching)

This refactoring improves code organization and makes the codebase easier to navigate and maintain.