### PR TITLE
feat: add automatic benchmark comparison against main branch baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main, beta ]
+    branches: [ main ]
+  push:
+    branches: [ main ]
 
 jobs:
   test:
@@ -237,6 +239,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    
     - name: Download all results
       uses: actions/download-artifact@v4
       with:
@@ -244,6 +251,7 @@ jobs:
         path: all-results
     
     - name: Aggregate results
+      id: aggregate
       run: |
         # Function to output to both stdout and GitHub step summary
         output_both() {
@@ -254,7 +262,11 @@ jobs:
         output_both "## Benchmark Results Summary"
         output_both ""
         
-        # Find all result JSON files and display them
+        # Create aggregated JSON file
+        echo "[" > aggregated-results.json
+        first=true
+        
+        # Find all result JSON files and aggregate them
         for result_dir in all-results/*/; do
           if [ -d "$result_dir" ]; then
             repo_name=$(basename "$result_dir" | sed 's/benchmark-results-//')
@@ -264,6 +276,14 @@ jobs:
             # Find the JSON file in the nested structure
             json_file=$(find "$result_dir" -name "*.json" -type f | head -1)
             if [ -f "$json_file" ]; then
+              # Add to aggregated results
+              if [ "$first" = true ]; then
+                first=false
+              else
+                echo "," >> aggregated-results.json
+              fi
+              cat "$json_file" | python3 -c "import sys, json; results = json.load(sys.stdin); [print(json.dumps(r)) for r in results]" >> aggregated-results.json
+              
               # Output JSON with proper markdown formatting
               output_both '```json'
               output_both "$(python3 -m json.tool "$json_file")"
@@ -274,3 +294,43 @@ jobs:
             output_both ""
           fi
         done
+        
+        echo "]" >> aggregated-results.json
+        
+        # Set output for artifact name
+        if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "artifact_name=benchmark-baseline-main" >> $GITHUB_OUTPUT
+        else
+          echo "artifact_name=benchmark-results-pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+        fi
+    
+    # Upload baseline when on main branch
+    - name: Upload baseline artifact
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-baseline-main
+        path: aggregated-results.json
+        retention-days: 90
+    
+    # Download and compare with baseline when on PR
+    - name: Download baseline for comparison
+      if: github.event_name == 'pull_request'
+      uses: dawidd6/action-download-artifact@v3
+      with:
+        workflow: ci.yml
+        branch: main
+        name: benchmark-baseline-main
+        path: baseline
+        if_no_artifact_found: warn
+    
+    - name: Compare with baseline
+      if: github.event_name == 'pull_request' && success()
+      run: |
+        if [ -f baseline/aggregated-results.json ]; then
+          python3 scripts/benchmark/compare_results.py baseline/aggregated-results.json aggregated-results.json || true
+          echo ""
+          echo "Note: Comparison only includes benchmarks that exist in both baseline and current results."
+        else
+          echo "No baseline found for comparison"
+        fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtest"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "pyo3",

--- a/scripts/benchmark/compare_results.py
+++ b/scripts/benchmark/compare_results.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Compare benchmark results between baseline and current run."""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, TypedDict
+
+
+class BenchmarkStatus(Enum):
+    SIGNIFICANT_REGRESSION = "significant_regression"
+    REGRESSION = "regression"
+    NO_CHANGE = "no_change"
+    IMPROVEMENT = "improvement"
+    SIGNIFICANT_IMPROVEMENT = "significant_improvement"
+
+
+class RtestMetrics(TypedDict):
+    mean: float
+    stddev: float
+    times: List[float]
+
+
+class BenchmarkResult(TypedDict, total=False):
+    repository: str
+    benchmark: str
+    rtest: RtestMetrics
+    error: str  # Optional field
+
+
+@dataclass(frozen=True)
+class ComparisonConfig:
+    regression_threshold: float
+    significant_threshold: float
+
+
+@dataclass(frozen=True)
+class BenchmarkComparison:
+    repository: str
+    benchmark: str
+    baseline_time: Optional[float]
+    current_time: Optional[float]
+    change_percentage: Optional[float]
+    status: BenchmarkStatus
+
+    def is_regression(self) -> bool:
+        """Check if this comparison represents a regression."""
+        return self.status in (BenchmarkStatus.REGRESSION, BenchmarkStatus.SIGNIFICANT_REGRESSION)
+
+
+STATUS_SYMBOLS = {
+    BenchmarkStatus.SIGNIFICANT_REGRESSION: "[!!]",
+    BenchmarkStatus.REGRESSION: "[!]",
+    BenchmarkStatus.NO_CHANGE: "[-]",
+    BenchmarkStatus.IMPROVEMENT: "[+]",
+    BenchmarkStatus.SIGNIFICANT_IMPROVEMENT: "[++]",
+}
+
+
+def load_results(file_path: Path) -> List[BenchmarkResult]:
+    """Load benchmark results from JSON file."""
+    with open(file_path) as f:
+        data: List[BenchmarkResult] = json.load(f)
+        return data
+
+
+def format_time(seconds: float) -> str:
+    """Format time in seconds to a readable string."""
+    if seconds < 0.001:
+        return f"{seconds * 1000000:.0f}μs"
+    elif seconds < 1:
+        return f"{seconds * 1000:.1f}ms"
+    else:
+        return f"{seconds:.2f}s"
+
+
+def calculate_percentage_change(base: float, current: float) -> float:
+    """Calculate percentage change. Returns 0 if base is 0."""
+    if base == 0:
+        return 0.0
+    return ((current - base) / base) * 100
+
+
+def classify_change(percentage: float, config: ComparisonConfig) -> BenchmarkStatus:
+    """Classify the change based on percentage and thresholds."""
+    if percentage > config.significant_threshold:
+        return BenchmarkStatus.SIGNIFICANT_REGRESSION
+    elif percentage > config.regression_threshold:
+        return BenchmarkStatus.REGRESSION
+    elif percentage < -config.significant_threshold:
+        return BenchmarkStatus.SIGNIFICANT_IMPROVEMENT
+    elif percentage < -config.regression_threshold:
+        return BenchmarkStatus.IMPROVEMENT
+    else:
+        return BenchmarkStatus.NO_CHANGE
+
+
+def create_result_index(results: List[BenchmarkResult]) -> Dict[str, BenchmarkResult]:
+    """Create a lookup dictionary from benchmark results."""
+    index = {}
+    for result in results:
+        if "error" not in result:
+            key = f"{result['repository']}:{result['benchmark']}"
+            index[key] = result
+    return index
+
+
+def analyze_results(
+    baseline: List[BenchmarkResult], current: List[BenchmarkResult], config: ComparisonConfig
+) -> List[BenchmarkComparison]:
+    """Analyze benchmark results and return comparison data."""
+    comparisons = []
+
+    baseline_index = create_result_index(baseline)
+    current_index = create_result_index(current)
+
+    for key in sorted(set(baseline_index.keys()) & set(current_index.keys())):
+        current_result = current_index[key]
+        baseline_result = baseline_index[key]
+
+        repo = current_result["repository"]
+        benchmark = current_result["benchmark"]
+        current_time = current_result["rtest"]["mean"]
+        baseline_time = baseline_result["rtest"]["mean"]
+
+        change_pct = calculate_percentage_change(baseline_time, current_time)
+        status = classify_change(change_pct, config)
+
+        comparisons.append(
+            BenchmarkComparison(
+                repository=repo,
+                benchmark=benchmark,
+                baseline_time=baseline_time,
+                current_time=current_time,
+                change_percentage=change_pct,
+                status=status,
+            )
+        )
+
+    return comparisons
+
+
+def format_comparison_row(comparison: BenchmarkComparison) -> str:
+    """Format a single comparison as a table row."""
+    repo = comparison.repository
+    benchmark = comparison.benchmark
+    symbol = STATUS_SYMBOLS[comparison.status]
+    # These are guaranteed to be non-None for compared benchmarks
+    baseline_str = format_time(comparison.baseline_time)  # type: ignore[arg-type]
+    current_str = format_time(comparison.current_time)  # type: ignore[arg-type]
+    change_str = f"{comparison.change_percentage:+.1f}%"
+
+    return f"| {repo} | {benchmark} | {baseline_str} | {current_str} | {change_str} | {symbol} |"
+
+
+def calculate_summary_stats(comparisons: List[BenchmarkComparison]) -> Dict[str, int]:
+    """Calculate summary statistics from comparisons."""
+    stats = {"total": len(comparisons), "regressions": 0, "improvements": 0, "no_change": 0}
+
+    for comparison in comparisons:
+        if comparison.status in (BenchmarkStatus.REGRESSION, BenchmarkStatus.SIGNIFICANT_REGRESSION):
+            stats["regressions"] += 1
+        elif comparison.status in (BenchmarkStatus.IMPROVEMENT, BenchmarkStatus.SIGNIFICANT_IMPROVEMENT):
+            stats["improvements"] += 1
+        else:
+            stats["no_change"] += 1
+
+    return stats
+
+
+def format_report(comparisons: List[BenchmarkComparison], config: ComparisonConfig) -> str:
+    """Format comparison results as a markdown report."""
+    lines = []
+
+    lines.append("")
+    lines.append("## Benchmark Comparison Report")
+    lines.append("")
+    lines.append("Comparing current results against baseline from `main` branch.")
+    lines.append("")
+
+    lines.append("| Repository | Benchmark | Baseline | Current | Change | Status |")
+    lines.append("|------------|-----------|----------|---------|--------|--------|")
+
+    for comparison in comparisons:
+        lines.append(format_comparison_row(comparison))
+
+    stats = calculate_summary_stats(comparisons)
+    lines.append("")
+    lines.append("### Summary")
+    lines.append("")
+    lines.append(f"- Total benchmarks: {stats['total']}")
+    lines.append(f"- Regressions (>{config.regression_threshold}% slower): {stats['regressions']}")
+    lines.append(f"- Improvements (>{config.regression_threshold}% faster): {stats['improvements']}")
+    lines.append(f"- No significant change: {stats['no_change']}")
+
+    lines.append("")
+    if stats["regressions"] > 0:
+        lines.append("**Performance regressions detected!**")
+        lines.append("Please review the results above to ensure these are expected.")
+    elif stats["improvements"] > 0:
+        lines.append("**Performance improvements detected!**")
+    else:
+        lines.append("**No significant performance changes detected.**")
+
+    lines.append("")
+    lines.append("### Legend")
+    sig_imp = STATUS_SYMBOLS[BenchmarkStatus.SIGNIFICANT_IMPROVEMENT]
+    lines.append(f"- {sig_imp} Significant improvement (>{config.significant_threshold}% faster)")
+    imp = STATUS_SYMBOLS[BenchmarkStatus.IMPROVEMENT]
+    lines.append(f"- {imp} Minor improvement ({config.regression_threshold}-{config.significant_threshold}% faster)")
+    lines.append(
+        f"- {STATUS_SYMBOLS[BenchmarkStatus.NO_CHANGE]} No significant change (±{config.regression_threshold}%)"
+    )
+    reg = STATUS_SYMBOLS[BenchmarkStatus.REGRESSION]
+    lines.append(f"- {reg} Minor regression ({config.regression_threshold}-{config.significant_threshold}% slower)")
+    sig_reg = STATUS_SYMBOLS[BenchmarkStatus.SIGNIFICANT_REGRESSION]
+    lines.append(f"- {sig_reg} Significant regression (>{config.significant_threshold}% slower)")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compare benchmark results between baseline and current run.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("baseline", type=Path, help="Path to baseline benchmark results JSON")
+
+    parser.add_argument("current", type=Path, help="Path to current benchmark results JSON")
+
+    parser.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=5.0,
+        help="Percentage threshold for marking a regression (default: 5.0)",
+    )
+
+    parser.add_argument(
+        "--significant-threshold",
+        type=float,
+        default=10.0,
+        help="Percentage threshold for marking a significant change (default: 10.0)",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main entry point."""
+    args = parse_args()
+
+    baseline_path: Path = args.baseline
+    current_path: Path = args.current
+
+    if not baseline_path.exists():
+        print(f"Error: Baseline file not found: {baseline_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not current_path.exists():
+        print(f"Error: Current results file not found: {current_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract typed values from args
+    regression_threshold: float = args.regression_threshold
+    significant_threshold: float = args.significant_threshold
+
+    config = ComparisonConfig(regression_threshold=regression_threshold, significant_threshold=significant_threshold)
+
+    try:
+        baseline_results = load_results(baseline_path)
+        current_results = load_results(current_path)
+
+        comparisons = analyze_results(baseline_results, current_results, config)
+        report = format_report(comparisons, config)
+
+        print(report)
+
+        if any(c.is_regression() for c in comparisons):
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "rtest"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
Implement a system for tracking performance changes between pull requests and the main branch. The CI workflow now generates baseline benchmark artifacts on every push to main, storing them for 90 days. When pull requests run benchmarks, they automatically download the most recent baseline and compare their results against it.

The comparison script provides detailed performance analysis with visual indicators for regressions and improvements, formatted as a markdown table in the GitHub Actions summary. This enables developers to immediately see the performance impact of their changes without manual intervention or external services.

Additionally removed references to the deprecated beta branch from the CI workflow to simplify the configuration.