### PR TITLE
feat: add parallel execution benchmarking with -n auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,29 +69,44 @@ The current implementation focuses on enhanced test collection and parallelizati
 ```
 Repository      pytest               rtest                Speedup
 -----------     ------               -----                -------
-FastAPI         5.477s ± 0.044s      0.096s ± 0.001s     56.82x
-Requests        0.446s ± 0.003s      0.041s ± 0.000s     10.89x
-Flask           0.479s ± 0.006s      0.045s ± 0.000s     10.60x
-Click           0.367s ± 0.002s      0.042s ± 0.000s     8.64x
-HTTPX           0.250s ± 0.003s      0.044s ± 0.000s     5.65x
-Scikit-learn    0.225s ± 0.002s      0.226s ± 0.002s     1.00x
-Pandas          0.239s ± 0.005s      0.506s ± 0.001s     0.47x
+FastAPI         5.583s ± 0.083s      0.096s ± 0.000s     58.00x
+Flask           0.502s ± 0.004s      0.044s ± 0.001s     11.35x
+Requests        0.442s ± 0.002s      0.040s ± 0.000s     11.09x
+Click           0.395s ± 0.001s      0.043s ± 0.000s     9.22x
+HTTPX           0.259s ± 0.003s      0.044s ± 0.000s     5.89x
+Scikit-learn    0.241s ± 0.003s      0.225s ± 0.001s     1.07x
+Pandas          0.242s ± 0.002s      0.514s ± 0.004s     0.47x
 ```
 
-### Test Execution Performance  
+### Test Execution Performance (Sequential)
 ```
 Repository      pytest               rtest                Speedup
 -----------     ------               -----                -------
-Flask           1.688s ± 0.008s      0.035s ± 0.000s     48.47x
-Click           1.353s ± 0.004s      0.034s ± 0.000s     40.23x
-FastAPI         0.652s ± 0.004s      0.035s ± 0.001s     18.43x
-Django          0.561s ± 0.016s      0.036s ± 0.001s     15.55x
-HTTPX           0.252s ± 0.004s      0.035s ± 0.000s     7.19x
-Pandas          0.235s ± 0.002s      0.061s ± 0.000s     3.81x
-Scikit-learn    0.224s ± 0.002s      0.060s ± 0.001s     3.73x
+Requests        7.488s ± 0.003s      0.034s ± 0.002s     219.09x
+Flask           1.724s ± 0.009s      0.035s ± 0.000s     49.00x
+Click           1.403s ± 0.006s      0.035s ± 0.000s     40.65x
+FastAPI         0.665s ± 0.007s      0.035s ± 0.000s     18.92x
+Django          0.577s ± 0.023s      0.037s ± 0.001s     15.77x
+HTTPX           0.259s ± 0.003s      0.034s ± 0.000s     7.51x
+Scikit-learn    0.239s ± 0.002s      0.060s ± 0.001s     3.97x
+Pandas          0.243s ± 0.003s      0.061s ± 0.001s     3.99x
 ```
 
-*Benchmarks performed using [hyperfine](https://github.com/sharkdp/hyperfine) with 20 runs, 3 warmup runs per measurement. Results show mean ± standard deviation across popular Python projects on Ubuntu Linux (GitHub Actions runner). Performance benchmarks include both sequential and parallel execution modes (using `-n auto --dist load`).*
+### Test Execution Performance (Parallel with -n auto)
+```
+Repository      pytest               rtest                Speedup
+-----------     ------               -----                -------
+Requests        8.241s ± 0.009s      0.034s ± 0.000s     243.79x
+Flask           1.995s ± 0.013s      0.035s ± 0.000s     56.32x
+Click           1.726s ± 0.028s      0.035s ± 0.000s     49.64x
+FastAPI         1.597s ± 0.013s      0.035s ± 0.000s     45.13x
+Django          1.311s ± 0.011s      0.036s ± 0.000s     36.81x
+HTTPX           0.258s ± 0.002s      0.034s ± 0.000s     7.54x
+Pandas          0.243s ± 0.002s      0.061s ± 0.001s     3.99x
+Scikit-learn    0.237s ± 0.001s      0.060s ± 0.001s     3.94x
+```
+
+*Benchmarks performed using [hyperfine](https://github.com/sharkdp/hyperfine) with 20 runs, 3 warmup runs per measurement. Results show mean ± standard deviation across popular Python projects on Ubuntu Linux (GitHub Actions runner).*
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Pandas          0.235s ± 0.002s      0.061s ± 0.000s     3.81x
 Scikit-learn    0.224s ± 0.002s      0.060s ± 0.001s     3.73x
 ```
 
-*Benchmarks performed using [hyperfine](https://github.com/sharkdp/hyperfine) with 20 runs, 3 warmup runs per measurement. Results show mean ± standard deviation across popular Python projects on Ubuntu Linux (GitHub Actions runner).*
+*Benchmarks performed using [hyperfine](https://github.com/sharkdp/hyperfine) with 20 runs, 3 warmup runs per measurement. Results show mean ± standard deviation across popular Python projects on Ubuntu Linux (GitHub Actions runner). Performance benchmarks include both sequential and parallel execution modes (using `-n auto --dist load`).*
 
 ## Quick Start
 

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -27,7 +27,20 @@ uv run python scripts/benchmark/benchmark_repositories.py --repositories click f
 
 The `repositories.yml` file contains:
 - Repository definitions (name, URL, test directory)
-- Benchmark configurations (collect_only, execution)
+- Benchmark configurations:
+  - `collect_only`: Test discovery performance
+  - `execution`: Sequential test execution performance
+  - `execution_parallel`: Parallel test execution performance using `-n auto --dist load`
+
+## Benchmark Types
+
+The benchmarking suite runs three types of performance tests:
+
+1. **Test Collection** (`collect_only`): Measures how fast each tool can discover tests without executing them
+2. **Sequential Execution** (`execution`): Measures test execution performance in a single process
+3. **Parallel Execution** (`execution_parallel`): Measures test execution performance using all available CPU cores with `-n auto --dist load`
+   - Uses `pytest-xdist` for pytest's parallel execution
+   - Uses rtest's built-in parallel execution
 
 ## Requirements
 

--- a/scripts/benchmark/benchmark_repositories.py
+++ b/scripts/benchmark/benchmark_repositories.py
@@ -221,7 +221,7 @@ class RepositoryManager:
         benchmark_dir = repo_path / ".benchmark"
         benchmark_dir.mkdir(exist_ok=True)
 
-        dependencies = f'"pytest", "rtest @ file://{self.project_root}"'
+        dependencies = f'"pytest", "pytest-xdist", "rtest @ file://{self.project_root}"'
 
         # Create pyproject.toml for isolated environment
         pyproject_path = benchmark_dir / "pyproject.toml"
@@ -563,7 +563,7 @@ def main() -> None:
         orchestrator = BenchmarkOrchestrator(config_path)
 
         # Run benchmarks
-        benchmark_types = ["collect_only"] if args.collect_only else ["collect_only", "execution"]
+        benchmark_types = ["collect_only"] if args.collect_only else ["collect_only", "execution", "execution_parallel"]
         results = orchestrator.run_benchmarks(args.repositories, benchmark_types)
         ResultFormatter.print_summary(results)
         filename = f"benchmark_results_{int(time.time())}.json"

--- a/scripts/benchmark/repositories.yml
+++ b/scripts/benchmark/repositories.yml
@@ -59,7 +59,7 @@ benchmark_configs:
     description: "Test execution performance"
     pytest_args: "--maxfail=3 -x"
     rtest_args: "--maxfail=3 -x"
-    timeout: 120
+    timeout: 300
     
   execution_parallel:
     description: "Test execution performance (parallel with -n auto)"

--- a/scripts/benchmark/repositories.yml
+++ b/scripts/benchmark/repositories.yml
@@ -60,3 +60,9 @@ benchmark_configs:
     pytest_args: "--maxfail=3 -x"
     rtest_args: "--maxfail=3 -x"
     timeout: 120
+    
+  execution_parallel:
+    description: "Test execution performance (parallel with -n auto)"
+    pytest_args: "--maxfail=3 -x -n auto --dist load"
+    rtest_args: "--maxfail=3 -x -n auto --dist load"
+    timeout: 300


### PR DESCRIPTION
- Add execution_parallel benchmark configuration using -n auto --dist load
- Install pytest-xdist for parallel pytest execution support
- Update benchmark script to include parallel execution in default runs
- Document new benchmark types in README files

This enables performance comparison of parallel test execution between
rtest and pytest using all available CPU cores.