### PR TITLE
fix(tests): use platform-agnostic path assertions for Windows compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtest"
-version = "0.0.26"
+version = "0.0.28"
 dependencies = [
  "clap",
  "glob",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "rtest-py"
-version = "0.0.26"
+version = "0.0.28"
 dependencies = [
  "clap",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ test_floating_numbers.py::TestAddFloatingNumbers::test_add_simple_floats
 
 We believe this difference is desirable, in that `TestAddNumbers` isn't collected twice from different modules.
 
+### Path Separator Handling
+`rtest` uses platform-specific path separators in test nodeids, while `pytest` normalizes all paths to use forward slashes (`/`) regardless of platform. For example:
+
+**On Windows:**
+- pytest shows: `tests/unit/test_example.py::test_function`
+- rtest shows: `tests\unit\test_example.py::test_function`
+
+**On Unix/macOS:**
+- Both show: `tests/unit/test_example.py::test_function`
+
+This difference is intentional as `rtest` preserves the native path format of the operating system.
+
 ## Contributing
 
 We welcome contributions! See [Contributing Guide](CONTRIBUTING.rst).

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1323,6 +1323,19 @@ class TestNested(TestBase):
 
     // Should find both the base test and the nested test with inheritance
     assert!(stdout.contains("test_base.py::TestBase::test_base_method"));
-    assert!(stdout.contains("tests/unit/test_nested.py::TestNested::test_base_method"));
-    assert!(stdout.contains("tests/unit/test_nested.py::TestNested::test_nested_method"));
+
+    // Use platform-agnostic path construction
+    let nested_test_path = std::path::Path::new("tests")
+        .join("unit")
+        .join("test_nested.py")
+        .display()
+        .to_string();
+    assert!(stdout.contains(&format!(
+        "{}::TestNested::test_base_method",
+        nested_test_path
+    )));
+    assert!(stdout.contains(&format!(
+        "{}::TestNested::test_nested_method",
+        nested_test_path
+    )));
 }

--- a/tests/test_collection_integration.py
+++ b/tests/test_collection_integration.py
@@ -1109,8 +1109,11 @@ class TestCollectionIntegration(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
             # Should find both the base test and the nested test with inheritance
             self.assertIn("test_base.py::TestBase::test_base_method", result.output)
-            self.assertIn("tests/unit/test_nested.py::TestNested::test_base_method", result.output)
-            self.assertIn("tests/unit/test_nested.py::TestNested::test_nested_method", result.output)
+
+            # Use platform-agnostic path construction
+            nested_test_path = str(Path("tests", "unit", "test_nested.py"))
+            self.assertIn(f"{nested_test_path}::TestNested::test_base_method", result.output)
+            self.assertIn(f"{nested_test_path}::TestNested::test_nested_method", result.output)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ wheels = [
 
 [[package]]
 name = "rtest"
-version = "0.0.26"
+version = "0.0.28"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
- Update `cli_integration.rs` tests to use `Path::join()` and `display()` for cross-platform path assertions
- Document intentional difference from `pytest`: `rtest` preserves platform-specific path separators while `pytest` normalizes all paths to forward slashes