### PR TITLE
ci: switch to tag-triggered PyPI releases

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,43 @@
+name: Prepare Release (semantic-release)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Optional override (major/minor/patch). Leave blank for auto."
+        required: false
+        type: string
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install semantic-release
+        run: |
+          pipx install python-semantic-release
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.release_type }}" ]; then
+            semantic-release version --${{ inputs.release_type }}
+          else
+            semantic-release version
+          fi
+          semantic-release publish
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,97 +1,61 @@
-name: Release
+name: Release (PyPI)
 
 on:
   push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.1.0)"
+        required: true
+        type: string
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    if: github.repository == 'hughhan1/rtest'
-    outputs:
-      new_release: ${{ steps.check_release.outputs.new_release }}
+  build:
+    name: Build wheels (${{ matrix.os }} / ${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64
+          - os: ubuntu-latest
+            target: aarch64
+          - os: macos-latest
+            target: x86_64
+          - os: macos-14
+            target: aarch64
+          - os: windows-2022
+            target: x64
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install python-semantic-release
-        run: pip install python-semantic-release
-
-      - name: Run semantic-release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version && semantic-release publish
-
-
-      - name: Check if release was created
-        id: check_release
-        run: |
-          if git describe --exact-match --tags HEAD 2>/dev/null; then
-            echo "new_release=true" >> $GITHUB_OUTPUT
-          else
-            echo "new_release=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build wheels
-        if: steps.check_release.outputs.new_release == 'true'
-        uses: PyO3/maturin-action@v1
-        with:
-          target: x86_64
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-          manylinux: auto
-
-      - name: Upload wheels
-        if: steps.check_release.outputs.new_release == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-release-x86_64
-          path: dist
-
-  linux:
-    runs-on: ${{ matrix.platform.runner }}
-    needs: release
-    if: needs.release.outputs.new_release == 'true'
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-latest
-            target: x86_64
-          - runner: ubuntu-latest
-            target: aarch64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          submodules: recursive
-
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
-          sccache: 'true'
           manylinux: auto
+          sccache: "true"
           before-script-linux: |
-            if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
+            if [ "${{ matrix.target }}" = "aarch64" ]; then
               apt-get update
               apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
               export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
@@ -102,77 +66,29 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
-
-
-  macos:
-    runs-on: ${{ matrix.platform.runner }}
-    needs: release
-    if: needs.release.outputs.new_release == 'true'
-    strategy:
-      matrix:
-        platform:
-          - runner: macos-latest
-            target: x86_64
-          - runner: macos-14
-            target: aarch64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          submodules: recursive
-
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
-
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    needs: release
-    if: needs.release.outputs.new_release == 'true'
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-2022
-            target: x64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          submodules: recursive
-
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: dist
 
   sdist:
+    name: Build sdist
     runs-on: ubuntu-latest
-    needs: release
-    if: needs.release.outputs.new_release == 'true'
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
           submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build sdist
         uses: PyO3/maturin-action@v1
@@ -183,13 +99,18 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-sdist
+          name: sdist
           path: dist
 
   publish:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [release, linux, macos, windows, sdist]
-    if: needs.release.outputs.new_release == 'true'
+    needs: [build, sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rtest
+    permissions:
+      id-token: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -197,7 +118,5 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Publish to PyPI
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,4 +1,4 @@
-name: Test Release
+name: Test Release (TestPyPI)
 
 on:
   push:
@@ -6,57 +6,43 @@ on:
       - beta
   workflow_dispatch:
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
-
 jobs:
-  test-release:
+  build-and-publish:
+    name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install python-semantic-release
-        run: pip install python-semantic-release
-
-      - name: Check what would be released
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --no-push
-
-      - name: Build wheels for testing
+      - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: x86_64
           args: --release --out dist --find-interpreter
-          sccache: 'true'
           manylinux: auto
+          sccache: "true"
 
-      - name: Upload to TestPyPI
-        if: github.ref == 'refs/heads/beta'
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           skip-existing: true
-
-      - name: Test install from TestPyPI
-        if: github.ref == 'refs/heads/beta'
-        run: |
-          sleep 60  # Wait for TestPyPI to process
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ rtest
-          python -c "import rtest; print('Test install successful')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dev = [
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version", "Cargo.toml:package.version", "rtest/Cargo.toml:package.version"]
 changelog_file = "CHANGELOG.md"
-upload_to_repository = true
+upload_to_repository = false
 upload_to_release = true
 hvcs = "github"
 branches = { main = {}, prerelease = { name = "beta", prerelease = true } }


### PR DESCRIPTION
Replace continuous delivery from `main` with tag-triggered releases following Python packaging best practices. This prevents accidental releases and gives explicit control over when versions are published.

`release.yml` now gets triggered by `v*` tags and manual dispatch only. `prepare-release.yml` is added for manual semantic-release execution. `test-release.yml` is updated to use OIDC for TestPyPI publishing.