### PR TITLE
refactor: improve Python type annotations with NamedTuple and modern syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,17 @@ rtest/
 - **Testing**: pytest with descriptive test names and good coverage
 - **Documentation**: Google-style docstrings for public APIs
 
+### Type Annotation Guidelines
+
+- **Prefer structured types over generic dicts**: Use `@dataclass(frozen=True)`, `NamedTuple`, or `TypedDict` instead of
+  `dict[str, Any]` or nested dictionaries when the structure is known
+- **Use modern generic syntax**: Prefer `list[str]`, `dict[str, int]`, `tuple[int, str]` over `List[str]`,
+  `Dict[str, int]`, `Tuple[int, str]` from the `typing` module. Add `from __future__ import annotations` when needed
+  for Python 3.9 compatibility
+- **Use union syntax**: Prefer `str | None` over `Optional[str]`
+- **Named tuples for return values**: When returning multiple values with fixed meaning, use `NamedTuple` or
+  `@dataclass` instead of bare `tuple[...]`
+
 ## Troubleshooting
 
 ### Build Issues

--- a/python/rtest/_rtest.pyi
+++ b/python/rtest/_rtest.pyi
@@ -1,11 +1,9 @@
 """Type stubs for the Rust module."""
 
-from typing import List, Optional
-
-def run_tests(pytest_args: Optional[List[str]] = ...) -> None:
+def run_tests(pytest_args: list[str] | None = ...) -> None:
     """Run tests using the Rust implementation."""
     ...
 
-def main_cli_with_args(argv: List[str]) -> None:
+def main_cli_with_args(argv: list[str]) -> None:
     """Main CLI entry point with arguments."""
     ...

--- a/python/rtest/mark.py
+++ b/python/rtest/mark.py
@@ -29,6 +29,7 @@ from typing import Callable, Sequence, TypeVar, Union
 
 # TypeVar for decorators that preserve function signatures
 # The bound includes "type" to support decorating classes as well as functions
+# Note: Union is required here (not |) because TypeVar bounds are evaluated at runtime
 F = TypeVar("F", bound=Union[Callable[..., object], type])
 
 # Deprecation warning messages for pytest marker compatibility

--- a/python/rtest/worker/runner.py
+++ b/python/rtest/worker/runner.py
@@ -14,7 +14,7 @@ import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from types import MappingProxyType, ModuleType
-from typing import Callable
+from typing import Callable, Literal
 
 
 @dataclass
@@ -22,7 +22,7 @@ class TestResult:
     """Result of a single test execution."""
 
     nodeid: str
-    outcome: str  # "passed", "failed", "error", "skipped"
+    outcome: Literal["passed", "failed", "error", "skipped"]
     duration_ms: float
     stdout: str = ""
     stderr: str = ""

--- a/scripts/benchmark/aggregate_results.py
+++ b/scripts/benchmark/aggregate_results.py
@@ -1,22 +1,24 @@
 #!/usr/bin/env python3
 """Aggregate benchmark results from multiple repositories into a single JSON file."""
 
+from __future__ import annotations
+
 import argparse
 import json
 from glob import glob
 from pathlib import Path
-from typing import Dict, List, Union, cast
+from typing import cast
 
 
-def find_result_files(results_dir: Path) -> List[Path]:
+def find_result_files(results_dir: Path) -> list[Path]:
     """Find all benchmark result JSON files in the given directory."""
     pattern = str(results_dir / "*" / "*" / "*.json")
     return [Path(f) for f in glob(pattern)]
 
 
-def aggregate_results(results_dir: Path, output_file: Path) -> List[Dict[str, Union[str, float]]]:
+def aggregate_results(results_dir: Path, output_file: Path) -> list[dict[str, str | float]]:
     """Aggregate all benchmark results into a single list."""
-    all_results: List[Dict[str, Union[str, float]]] = []
+    all_results: list[dict[str, str | float]] = []
 
     # Find all result directories
     result_dirs = sorted([d for d in results_dir.iterdir() if d.is_dir()])
@@ -33,7 +35,7 @@ def aggregate_results(results_dir: Path, output_file: Path) -> List[Dict[str, Un
         if json_files:
             # Use the first JSON file found
             with open(json_files[0]) as f:
-                results = cast(List[Dict[str, Union[str, float]]], json.load(f))
+                results = cast(list[dict[str, str | float]], json.load(f))
                 all_results.extend(results)
 
             # Pretty print for summary

--- a/scripts/benchmark/compare_results.py
+++ b/scripts/benchmark/compare_results.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Compare benchmark results between baseline and current run."""
 
+from __future__ import annotations
+
 import argparse
 import json
 import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, TypedDict
+from typing import TypedDict
 
 
 class BenchmarkStatus(Enum):
@@ -21,7 +23,7 @@ class BenchmarkStatus(Enum):
 class RtestMetrics(TypedDict):
     mean: float
     stddev: float
-    times: List[float]
+    times: list[float]
 
 
 class BenchmarkResult(TypedDict, total=False):
@@ -41,9 +43,9 @@ class ComparisonConfig:
 class BenchmarkComparison:
     repository: str
     benchmark: str
-    baseline_time: Optional[float]
-    current_time: Optional[float]
-    change_percentage: Optional[float]
+    baseline_time: float | None
+    current_time: float | None
+    change_percentage: float | None
     status: BenchmarkStatus
 
     def is_regression(self) -> bool:
@@ -60,10 +62,10 @@ STATUS_SYMBOLS = {
 }
 
 
-def load_results(file_path: Path) -> List[BenchmarkResult]:
+def load_results(file_path: Path) -> list[BenchmarkResult]:
     """Load benchmark results from JSON file."""
     with open(file_path) as f:
-        data: List[BenchmarkResult] = json.load(f)
+        data: list[BenchmarkResult] = json.load(f)
         return data
 
 
@@ -98,7 +100,7 @@ def classify_change(percentage: float, config: ComparisonConfig) -> BenchmarkSta
         return BenchmarkStatus.NO_CHANGE
 
 
-def create_result_index(results: List[BenchmarkResult]) -> Dict[str, BenchmarkResult]:
+def create_result_index(results: list[BenchmarkResult]) -> dict[str, BenchmarkResult]:
     """Create a lookup dictionary from benchmark results."""
     index = {}
     for result in results:
@@ -109,8 +111,8 @@ def create_result_index(results: List[BenchmarkResult]) -> Dict[str, BenchmarkRe
 
 
 def analyze_results(
-    baseline: List[BenchmarkResult], current: List[BenchmarkResult], config: ComparisonConfig
-) -> List[BenchmarkComparison]:
+    baseline: list[BenchmarkResult], current: list[BenchmarkResult], config: ComparisonConfig
+) -> list[BenchmarkComparison]:
     """Analyze benchmark results and return comparison data."""
     comparisons = []
 
@@ -156,7 +158,7 @@ def format_comparison_row(comparison: BenchmarkComparison) -> str:
     return f"| {repo} | {benchmark} | {baseline_str} | {current_str} | {change_str} | {symbol} |"
 
 
-def calculate_summary_stats(comparisons: List[BenchmarkComparison]) -> Dict[str, int]:
+def calculate_summary_stats(comparisons: list[BenchmarkComparison]) -> dict[str, int]:
     """Calculate summary statistics from comparisons."""
     stats = {"total": len(comparisons), "regressions": 0, "improvements": 0, "no_change": 0}
 
@@ -171,7 +173,7 @@ def calculate_summary_stats(comparisons: List[BenchmarkComparison]) -> Dict[str,
     return stats
 
 
-def format_report(comparisons: List[BenchmarkComparison], config: ComparisonConfig) -> str:
+def format_report(comparisons: list[BenchmarkComparison], config: ComparisonConfig) -> str:
     """Format comparison results as a markdown report."""
     lines = []
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,11 @@
 """Common test helper functions for rtest tests."""
 
+from __future__ import annotations
+
 import tempfile
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional
 
 from test_utils import run_rtest
 
@@ -14,7 +16,7 @@ class CollectionResult:
     Provides flexible access to output as either string or list of lines.
     """
 
-    def __init__(self, returncode: int, stdout: str, stderr: str = ""):
+    def __init__(self, returncode: int, stdout: str, stderr: str = "") -> None:
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
@@ -27,13 +29,13 @@ class CollectionResult:
         return self._output
 
     @property
-    def output_lines(self) -> List[str]:
+    def output_lines(self) -> list[str]:
         """Get output as a list of lines."""
         return self._output_lines
 
 
 @contextmanager
-def create_test_project(files: Dict[str, str]) -> Iterator[Path]:
+def create_test_project(files: dict[str, str]) -> Iterator[Path]:
     """Create a temporary project with the specified test files.
 
     Args:
@@ -58,7 +60,7 @@ def create_test_project(files: Dict[str, str]) -> Iterator[Path]:
         yield project_path
 
 
-def run_collection(project_path: Path, env: Optional[Dict[str, str]] = None) -> CollectionResult:
+def run_collection(project_path: Path, env: dict[str, str] | None = None) -> CollectionResult:
     """Run test collection and return result with flexible output access.
 
     Args:
@@ -72,7 +74,7 @@ def run_collection(project_path: Path, env: Optional[Dict[str, str]] = None) -> 
     return CollectionResult(returncode, stdout, stderr)
 
 
-def assert_tests_found(output_lines: List[str], expected_tests: List[str]) -> None:
+def assert_tests_found(output_lines: list[str], expected_tests: list[str]) -> None:
     """Assert that all expected tests are found in the output.
 
     Args:
@@ -83,7 +85,7 @@ def assert_tests_found(output_lines: List[str], expected_tests: List[str]) -> No
         assert any(test in line for line in output_lines), f"Should find test: {test}"
 
 
-def assert_patterns_not_found(output: str, patterns: List[str]) -> None:
+def assert_patterns_not_found(output: str, patterns: list[str]) -> None:
     """Assert that specified patterns are not found in the output.
 
     Args:
@@ -94,7 +96,7 @@ def assert_patterns_not_found(output: str, patterns: List[str]) -> None:
         assert pattern not in output, f"Should not find: {pattern}"
 
 
-def count_collected_tests(output_lines: List[str]) -> int:
+def count_collected_tests(output_lines: list[str]) -> int:
     """Count the number of collected tests from output lines.
 
     Args:
@@ -106,7 +108,7 @@ def count_collected_tests(output_lines: List[str]) -> int:
     return len([line for line in output_lines if "::" in line and "test_" in line])
 
 
-def extract_test_lines(output_lines: List[str]) -> List[str]:
+def extract_test_lines(output_lines: list[str]) -> list[str]:
     """Extract and clean test lines from output.
 
     Args:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,20 @@
 """Common test utilities for rtest tests."""
 
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
-from typing import Dict, List, Optional
+from typing import NamedTuple
 
 
-def run_rtest(args: List[str], cwd: Optional[str] = None, env: Optional[Dict[str, str]] = None) -> tuple[int, str, str]:
+class RtestResult(NamedTuple):
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_rtest(args: list[str], cwd: str | None = None, env: dict[str, str] | None = None) -> RtestResult:
     """Helper to run rtest binary and capture output.
 
     Args:
@@ -15,7 +23,7 @@ def run_rtest(args: List[str], cwd: Optional[str] = None, env: Optional[Dict[str
         env: Environment variables to use (if None, uses current environment)
 
     Returns:
-        tuple: (returncode, stdout, stderr)
+        RtestResult: Named tuple with (returncode, stdout, stderr)
     """
 
     # On Windows, console scripts are installed in the Scripts subdirectory
@@ -39,4 +47,4 @@ def run_rtest(args: List[str], cwd: Optional[str] = None, env: Optional[Dict[str
         cwd=cwd,
         env=env,
     )
-    return result.returncode, result.stdout, result.stderr
+    return RtestResult(result.returncode, result.stdout, result.stderr)


### PR DESCRIPTION
## Summary
- Adds `RtestResult` NamedTuple to replace bare `tuple[int, str, str]` return type in `test_utils.py`
- Modernizes type annotations to use `list[]`, `dict[]`, and union syntax (`|`) instead of `typing.List`, `typing.Dict`, `typing.Optional`
- Adds `from __future__ import annotations` where needed for Python 3.9 compatibility
- Adds Type Annotation Guidelines section to AGENTS.md

## Files Changed
- `tests/test_utils.py` - Added `RtestResult` NamedTuple, modernized type hints
- `tests/test_helpers.py` - Modernized type hints
- `scripts/benchmark/compare_results.py` - Modernized type hints
- `scripts/benchmark/aggregate_results.py` - Modernized type hints
- `AGENTS.md` - Added Type Annotation Guidelines section

## Test plan
- [ ] CI passes
- [ ] Type checking passes with mypy
- [ ] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)