### PR TITLE
fix: native runner respects python_files from pyproject.toml

### DIFF
--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -7,3 +7,5 @@ pub mod error;
 pub mod nodes;
 pub mod types;
 mod utils;
+
+pub use utils::glob_match;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ pub mod worker;
 
 pub use collection::error::{CollectionError, CollectionResult};
 pub use collection_integration::{collect_tests_rust, display_collection_results};
-pub use native_runner::{collect_test_files, execute_native, NativeRunnerConfig};
+pub use native_runner::{
+    collect_test_files, default_python_files, execute_native, NativeRunnerConfig,
+};
 #[cfg(feature = "extension-module")]
 pub use pyo3::_rtest;
 pub use pytest_executor::execute_tests;


### PR DESCRIPTION
## Summary

- Parse `python_files` configuration from `[tool.pytest.ini_options]` in `pyproject.toml`
- Use configured patterns for test file collection in the native runner
- Fall back to default pytest patterns (`test_*.py`, `*_test.py`) when not configured

## Changes

- **src/config.rs**: Extended `PytestConfig` to parse `python_files` from pyproject.toml
- **src/native_runner.rs**: Updated `NativeRunnerConfig` and `is_test_file()` to use glob matching against configured patterns
- **src/collection/mod.rs**: Exposed `glob_match` utility for reuse
- **src/pyo3.rs**: Wired up config reading and pattern passing
- **src/lib.rs**: Added `default_python_files` to exports

## Test plan

- [x] Cargo tests pass
- [x] Python tests pass (`uv run pytest tests/`)
- [x] Ruff linting passes
- [x] Cargo clippy passes

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)