### PR TITLE
feat: native runner respects python_classes from pyproject.toml

### DIFF
--- a/python/rtest/worker/__main__.py
+++ b/python/rtest/worker/__main__.py
@@ -30,6 +30,12 @@ def main() -> int:
         help="Output JSONL file path for results",
     )
     parser.add_argument(
+        "--python-classes",
+        nargs="+",
+        default=["Test*"],
+        help="Patterns for test class names (default: Test*)",
+    )
+    parser.add_argument(
         "files",
         nargs="+",
         type=Path,
@@ -42,11 +48,13 @@ def main() -> int:
     root: Path = args.root
     output_file: Path = args.out
     test_files: list[Path] = args.files
+    python_classes: list[str] = args.python_classes
 
     return run_tests(
         root=root,
         output_file=output_file,
         test_files=test_files,
+        python_classes=python_classes,
     )
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@ pub mod worker;
 pub use collection::error::{CollectionError, CollectionResult};
 pub use collection_integration::{collect_tests_rust, display_collection_results};
 pub use native_runner::{
-    collect_test_files, default_python_files, execute_native, NativeRunnerConfig,
+    collect_test_files, default_python_classes, default_python_files, execute_native,
+    NativeRunnerConfig,
 };
 #[cfg(feature = "extension-module")]
 pub use pyo3::_rtest;

--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -8,9 +8,9 @@ use std::path::PathBuf;
 use crate::cli::{Args, Runner};
 use crate::config::read_pytest_config;
 use crate::{
-    collect_test_files, collect_tests_rust, default_python_files, determine_worker_count,
-    display_collection_results, execute_native, execute_tests, execute_tests_parallel, subproject,
-    NativeRunnerConfig, ParallelExecutionConfig,
+    collect_test_files, collect_tests_rust, default_python_classes, default_python_files,
+    determine_worker_count, display_collection_results, execute_native, execute_tests,
+    execute_tests_parallel, subproject, NativeRunnerConfig, ParallelExecutionConfig,
 };
 
 /// Get the current working directory, returning an error message on failure.
@@ -201,12 +201,17 @@ fn main_cli_with_args(py: Python, argv: Vec<String>) {
                 std::process::exit(0);
             }
 
-            // Read pytest configuration for python_files patterns
+            // Read pytest configuration for collection patterns
             let pytest_config = read_pytest_config(&rootpath);
             let python_files = if pytest_config.python_files.is_empty() {
                 default_python_files()
             } else {
                 pytest_config.python_files
+            };
+            let python_classes = if pytest_config.python_classes.is_empty() {
+                default_python_classes()
+            } else {
+                pytest_config.python_classes
             };
 
             // For execution, still use file-based collection (worker handles discovery)
@@ -217,6 +222,7 @@ fn main_cli_with_args(py: Python, argv: Vec<String>) {
                 root_path: rootpath,
                 num_workers: worker_count,
                 python_files,
+                python_classes,
             };
 
             let exit_code = execute_native(&config, test_files);


### PR DESCRIPTION
## Summary

Parse `python_classes` configuration from `[tool.pytest.ini_options]` in `pyproject.toml` and use it for test class discovery in the native runner.

**Stacked on:** #84 (`fix/native-runner-python-files`)

## Changes

**Rust side:**
- `src/config.rs`: Extended `PytestConfig` to parse `python_classes`
- `src/native_runner.rs`: Added to config, pass `--python-classes` to worker
- `src/pyo3.rs`: Wired up config reading
- `src/lib.rs`: Added `default_python_classes` export

**Python side:**
- `python/rtest/worker/__main__.py`: Added `--python-classes` CLI argument
- `python/rtest/worker/runner.py`: Implemented pattern matching, updated `_is_test_class()`

## Test plan

- [x] Cargo tests pass (including new `test_read_pytest_config_with_python_classes`)
- [x] Python tests pass (`uv run pytest tests/`)
- [x] Ruff linting passes

Part of #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)