### PR TITLE
feat(native-runner): add python_functions pattern support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3814abc7da8ab18d2fd820f5b540b5e39b6af0a32de1bdd7c47576693074843"
+checksum = "ab21d7bd2c625f2064f04ce54bcb88bc57c45724cde45cba326d784e22d3f71a"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "get-size2"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfe2cec5b5ce8fb94dcdb16a1708baa4d0609cc3ce305ca5d3f6f2ffb59baed"
+checksum = "879272b0de109e2b67b39fcfe3d25fdbba96ac07e44a254f5a0b4d7ff55340cb"
 dependencies = [
  "compact_str",
  "get-size-derive2",

--- a/python/rtest/worker/__main__.py
+++ b/python/rtest/worker/__main__.py
@@ -33,7 +33,13 @@ def main() -> int:
         "--python-classes",
         nargs="+",
         default=["Test*"],
-        help="Patterns for test class names (default: Test*)",
+        help="Glob patterns for test class names using fnmatch syntax (default: Test*)",
+    )
+    parser.add_argument(
+        "--python-functions",
+        nargs="+",
+        default=["test*"],
+        help="Glob patterns for test function/method names using fnmatch syntax (default: test*)",
     )
     parser.add_argument(
         "files",
@@ -49,12 +55,14 @@ def main() -> int:
     output_file: Path = args.out
     test_files: list[Path] = args.files
     python_classes: list[str] = args.python_classes
+    python_functions: list[str] = args.python_functions
 
     return run_tests(
         root=root,
         output_file=output_file,
         test_files=test_files,
         python_classes=python_classes,
+        python_functions=python_functions,
     )
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ pub mod worker;
 pub use collection::error::{CollectionError, CollectionResult};
 pub use collection_integration::{collect_tests_rust, display_collection_results};
 pub use native_runner::{
-    collect_test_files, default_python_classes, default_python_files, execute_native,
-    NativeRunnerConfig,
+    collect_test_files, default_python_classes, default_python_files, default_python_functions,
+    execute_native, NativeRunnerConfig,
 };
 #[cfg(feature = "extension-module")]
 pub use pyo3::_rtest;

--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -9,8 +9,8 @@ use crate::cli::{Args, Runner};
 use crate::config::read_pytest_config;
 use crate::{
     collect_test_files, collect_tests_rust, default_python_classes, default_python_files,
-    determine_worker_count, display_collection_results, execute_native, execute_tests,
-    execute_tests_parallel, subproject, NativeRunnerConfig, ParallelExecutionConfig,
+    default_python_functions, determine_worker_count, display_collection_results, execute_native,
+    execute_tests, execute_tests_parallel, subproject, NativeRunnerConfig, ParallelExecutionConfig,
 };
 
 /// Get the current working directory, returning an error message on failure.
@@ -213,6 +213,11 @@ fn main_cli_with_args(py: Python, argv: Vec<String>) {
             } else {
                 pytest_config.python_classes
             };
+            let python_functions = if pytest_config.python_functions.is_empty() {
+                default_python_functions()
+            } else {
+                pytest_config.python_functions
+            };
 
             // For execution, still use file-based collection (worker handles discovery)
             let test_files = collect_test_files(&rootpath, &args.files, &python_files);
@@ -223,6 +228,7 @@ fn main_cli_with_args(py: Python, argv: Vec<String>) {
                 num_workers: worker_count,
                 python_files,
                 python_classes,
+                python_functions,
             };
 
             let exit_code = execute_native(&config, test_files);

--- a/src/python_discovery/discovery.rs
+++ b/src/python_discovery/discovery.rs
@@ -246,14 +246,14 @@ class TestMultiLevel(TestDerived):
         // Check that TestBase has its own methods
         let base_tests: Vec<&TestInfo> = tests
             .iter()
-            .filter(|t| t.class_name.as_ref().map_or(false, |c| c == "TestBase"))
+            .filter(|t| t.class_name.as_ref().is_some_and(|c| c == "TestBase"))
             .collect();
         assert_eq!(base_tests.len(), 2);
 
         // Check that TestDerived has both inherited and its own methods
         let derived_tests: Vec<&TestInfo> = tests
             .iter()
-            .filter(|t| t.class_name.as_ref().map_or(false, |c| c == "TestDerived"))
+            .filter(|t| t.class_name.as_ref().is_some_and(|c| c == "TestDerived"))
             .collect();
         assert_eq!(derived_tests.len(), 3);
 
@@ -266,11 +266,7 @@ class TestMultiLevel(TestDerived):
         // Check that TestMultiLevel has inherited and its own methods
         let multi_tests: Vec<&TestInfo> = tests
             .iter()
-            .filter(|t| {
-                t.class_name
-                    .as_ref()
-                    .map_or(false, |c| c == "TestMultiLevel")
-            })
+            .filter(|t| t.class_name.as_ref().is_some_and(|c| c == "TestMultiLevel"))
             .collect();
         assert_eq!(multi_tests.len(), 2);
 
@@ -350,6 +346,6 @@ class TestDerived(TestBase):
         // All should be under TestDerived class
         assert!(tests
             .iter()
-            .all(|t| t.class_name.as_ref().map_or(false, |c| c == "TestDerived")));
+            .all(|t| t.class_name.as_ref().is_some_and(|c| c == "TestDerived")));
     }
 }


### PR DESCRIPTION
## Summary

- Parses `python_functions` from `[tool.pytest.ini_options]` in pyproject.toml
- Adds `python_functions` field to `NativeRunnerConfig` with default `["test*"]`
- Passes `--python-functions` patterns to Python worker CLI
- Updates `_is_test_function()` to use pattern matching instead of hardcoded prefix
- Updates method discovery in test classes to use `python_functions` patterns

This completes the pytest collection configuration support for issue #82:
- `python_files` (PR #84) - MERGED
- `python_classes` (PR #87)
- `python_functions` (this PR)

## Test plan

- [x] `cargo test` - all 82 Rust tests pass
- [x] `uv run pytest tests/` - all 84 Python tests pass
- [x] `cargo clippy` - no new warnings
- [x] `uv run ruff check python/ tests/ scripts/` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)