### PR TITLE
fix(ci): use --lib instead of --bin for clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       run: cargo fmt -- --check
 
     - name: Run clippy
-      run: cargo clippy -p rtest --bin rtest -- -D warnings
+      run: cargo clippy -p rtest --lib -- -D warnings
 
   # Setup job that installs dependencies once
   benchmark-setup:


### PR DESCRIPTION
## Summary

Fix CI clippy command that incorrectly uses `--bin rtest` when `rtest` is a library crate.

## Changes

- Change `cargo clippy -p rtest --bin rtest` to `cargo clippy -p rtest --lib`

## Root Cause

The Cargo.toml only defines a `[lib]` section with no `[[bin]]` target, so `--bin rtest` fails with:
```
error: no bin target named `rtest` in `rtest` package
```