### PR TITLE
fix: resolve clippy warnings with design patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ cargo clippy
 cargo clippy --all-targets -- -D warnings
 
 # Run clippy on specific package
-cargo clippy -p rtest --bin rtest -- -D warnings
+cargo clippy -p rtest --lib -- -D warnings
 ```
 
 ### Running All Quality Checks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use native_runner::{
 #[cfg(feature = "extension-module")]
 pub use pyo3::_rtest;
 pub use pytest_executor::execute_tests;
-pub use runner::{execute_tests_parallel, PytestRunner};
+pub use runner::{execute_tests_parallel, ParallelExecutionConfig, PytestRunner};
 pub use scheduler::{create_scheduler, DistributionMode};
 pub use utils::determine_worker_count;
-pub use worker::WorkerPool;
+pub use worker::{WorkerPool, WorkerTask};

--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -9,8 +9,8 @@ use crate::cli::{Args, Runner};
 use crate::config::read_pytest_config;
 use crate::{
     collect_test_files, collect_tests_rust, default_python_files, determine_worker_count,
-    display_collection_results, execute_native, execute_tests, execute_tests_parallel, subproject,
-    NativeRunnerConfig,
+    display_collection_results, execute_native, execute_tests, execute_tests_parallel,
+    subproject, NativeRunnerConfig, ParallelExecutionConfig,
 };
 
 /// Get the current working directory, returning an error message on failure.
@@ -284,16 +284,16 @@ fn main_cli_with_args(py: Python, argv: Vec<String>) {
 
                 overall_exit_code
             } else {
-                execute_tests_parallel(
-                    &runner.program,
-                    &runner.initial_args,
-                    test_nodes,
+                let config = ParallelExecutionConfig {
+                    program: &runner.program,
+                    initial_args: &runner.initial_args,
                     worker_count,
-                    &args.dist,
-                    &rootpath,
-                    true,
-                    &runner.env_vars,
-                )
+                    dist_mode: &args.dist,
+                    rootpath: &rootpath,
+                    use_subprojects: true,
+                    env_vars: &runner.env_vars,
+                };
+                execute_tests_parallel(&config, test_nodes)
             };
             std::process::exit(exit_code);
         }

--- a/src/python_discovery/discovery.rs
+++ b/src/python_discovery/discovery.rs
@@ -72,6 +72,7 @@ pub fn discover_tests_with_inheritance(
 /// Convert a file path to a module path
 fn path_to_module_path(file_path: &Path, root_path: &Path) -> Vec<String> {
     let relative = file_path.strip_prefix(root_path).unwrap_or(file_path);
+    let last_component = relative.components().next_back();
 
     let mut parts = Vec::new();
 
@@ -80,7 +81,7 @@ fn path_to_module_path(file_path: &Path, root_path: &Path) -> Vec<String> {
             let name_str = name.to_string_lossy();
 
             // Strip .py extension from the last component
-            if name_str.ends_with(".py") && component == relative.components().last().unwrap() {
+            if name_str.ends_with(".py") && Some(component) == last_component {
                 let without_ext = name_str.strip_suffix(".py").unwrap();
                 if without_ext != "__init__" {
                     parts.push(without_ext.to_string());

--- a/src/python_discovery/module_resolver.rs
+++ b/src/python_discovery/module_resolver.rs
@@ -88,12 +88,12 @@ impl ModuleResolver {
     fn try_resolve_in_search_path(
         &self,
         module_path: &[String],
-        search_path: &PathBuf,
+        search_path: &Path,
     ) -> Result<PathBuf, ()> {
         let possible_paths = self.get_possible_paths_in_root(module_path, search_path);
 
         for path in &possible_paths {
-            if std::fs::metadata(&path).is_ok() {
+            if std::fs::metadata(path).is_ok() {
                 return Ok(path.clone());
             }
         }
@@ -102,13 +102,13 @@ impl ModuleResolver {
     }
 
     /// Get all possible file paths for a module in a specific root directory
-    fn get_possible_paths_in_root(&self, module_path: &[String], root: &PathBuf) -> Vec<PathBuf> {
+    fn get_possible_paths_in_root(&self, module_path: &[String], root: &Path) -> Vec<PathBuf> {
         if module_path.is_empty() {
             return Vec::new();
         }
 
         let mut paths = Vec::new();
-        let mut base_dir = root.clone();
+        let mut base_dir = root.to_path_buf();
 
         // Build the base directory path from all but the last component
         if module_path.len() > 1 {


### PR DESCRIPTION
## Summary

- Fix `double_ended_iterator_last` lint in discovery.rs by using `next_back()` instead of `last()`
- Fix `ptr_arg` and `needless_borrows_for_generic_args` in module_resolver.rs by using `&Path` instead of `&PathBuf`
- Resolve `too_many_arguments` in worker.rs by introducing `WorkerTask` struct
- Resolve `too_many_arguments` in runner.rs by introducing `ParallelExecutionConfig` struct

These changes allow CI to pass with `cargo clippy -- -D warnings`.

## Test plan

- [x] All 80 Rust tests pass (`cargo test`)
- [x] `cargo clippy -p rtest --lib -- -D warnings` passes with no warnings