### PR TITLE
fix: apply rustfmt and add pre-commit checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,20 @@ cargo clippy -p rtest --lib -- -D warnings
    git commit -m "feat: add new feature description"
    ```
 
+### Pre-Commit Checklist
+
+**Always run formatters before committing** to avoid CI failures:
+
+```bash
+# Rust formatting (required)
+cargo fmt
+
+# Python formatting (if Python files changed)
+uv run ruff format python/ tests/ scripts/
+```
+
+CI runs `cargo fmt -- --check` and `uv run ruff format --check` which will fail if code is not formatted.
+
 ### Debugging Collection Issues
 
 ```bash

--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -9,8 +9,8 @@ use crate::cli::{Args, Runner};
 use crate::config::read_pytest_config;
 use crate::{
     collect_test_files, collect_tests_rust, default_python_files, determine_worker_count,
-    display_collection_results, execute_native, execute_tests, execute_tests_parallel,
-    subproject, NativeRunnerConfig, ParallelExecutionConfig,
+    display_collection_results, execute_native, execute_tests, execute_tests_parallel, subproject,
+    NativeRunnerConfig, ParallelExecutionConfig,
 };
 
 /// Get the current working directory, returning an error message on failure.


### PR DESCRIPTION
## Summary
- Apply rustfmt to `src/pyo3.rs` to fix CI formatting check failure
- Add "Pre-Commit Checklist" section to `AGENTS.md` to prevent future formatting issues

## Test plan
- [ ] CI passes `cargo fmt -- --check`