### PR TITLE
feat: implement lazy collection for explicit file paths

### DIFF
--- a/src/collection/error.rs
+++ b/src/collection/error.rs
@@ -1,6 +1,7 @@
 //! Collection error types.
 
 use std::fmt;
+use std::path::PathBuf;
 
 /// Result type for collection operations
 pub type CollectionResult<T> = Result<T, CollectionError>;
@@ -13,6 +14,7 @@ pub enum CollectionError {
     ParseError(String),
     ImportError(String),
     SkipError(String),
+    FileNotFound(PathBuf),
 }
 
 impl fmt::Display for CollectionError {
@@ -22,6 +24,9 @@ impl fmt::Display for CollectionError {
             Self::ParseError(e) => write!(f, "Parse error: {e}"),
             Self::ImportError(e) => write!(f, "Import error: {e}"),
             Self::SkipError(e) => write!(f, "Skip: {e}"),
+            Self::FileNotFound(path) => {
+                write!(f, "file or directory not found: {}", path.display())
+            }
         }
     }
 }

--- a/src/collection_integration.rs
+++ b/src/collection_integration.rs
@@ -97,6 +97,12 @@ pub fn display_collection_results(test_nodes: &[String], errors: &CollectionErro
                 CollectionError::SkipError(msg) => {
                     println!("{RED}E   Skipped: {msg}{RESET}");
                 }
+                CollectionError::FileNotFound(path) => {
+                    println!(
+                        "{RED}E   file or directory not found: {}{RESET}",
+                        path.display()
+                    );
+                }
             }
         }
         println!(


### PR DESCRIPTION
## Summary

- Only parse test files that users explicitly specify (lazy collection)
- Performance boost when running specific files/dirs
- Nonexistent paths now fail with exit code 4 (pytest compatibility)

## Changes

- Add `resolve_args()` helper to convert args to absolute paths
- Add `FileNotFound` error variant for nonexistent paths
- Validate paths exist before collection
- Handle `FileNotFound` with exit code 4 and proper error message
- Add test helpers and 4 integration tests

## Test plan

- [x] Single file → only that file parsed
- [x] Multiple files → only those files parsed
- [x] Directory → only files in that directory parsed
- [x] No args → full collection (testpaths config)
- [x] Nonexistent path → error + exit code 4
- [x] Valid + nonexistent → fails, no collection

Closes #97