### PR TITLE
Overhaul benchmark script and add execution benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
     
     - name: Run benchmark for ${{ matrix.repository }}
       run: |
-        uv run python scripts/benchmark/benchmark_repositories.py --source local --repositories ${{ matrix.repository }} --collect-only
+        uv run python scripts/benchmark/benchmark_repositories.py --source local --repositories ${{ matrix.repository }}
     
     - name: Upload results
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -29,6 +29,46 @@ hyperfine --warmup 3 --min-runs 20 --max-runs 20 \
 | [httpx](https://github.com/encode/httpx) | 1.71 s ± 0.76 s | 51 ms ± 5 ms | **33.53x** |
 | [pydantic](https://github.com/pydantic/pydantic) | 2.84 s ± 0.24 s | 121 ms ± 9 ms | **23.42x** |
 | [fastapi](https://github.com/tiangolo/fastapi) | 2.98 s ± 0.29 s | 107 ms ± 14 ms | **27.80x** |
+| [more-itertools](https://github.com/more-itertools/more-itertools) | 209 ms ± 20 ms | 28 ms ± 1 ms | **7.39x** |
+
+### Test Execution (`--runner native`)
+
+For repositories that don't rely on pytest fixtures or conftest.py, the native runner can execute tests directly:
+
+```bash
+hyperfine --warmup 3 --min-runs 20 --max-runs 20 \
+  --command-name pytest --command-name rtest \
+  ".venv/bin/pytest tests" \
+  ".venv/bin/rtest --runner native tests"
+```
+
+| Repository | pytest | rtest | Speedup |
+|------------|--------|-------|---------|
+| [more-itertools](https://github.com/more-itertools/more-itertools) | 17.96 s ± 2.17 s | 2.49 s ± 0.41 s | **7.20x** |
+
+> **Note**: Native runner execution benchmarks are limited to repositories that use simple test patterns (unittest.TestCase,
+> plain assertions) without pytest fixtures. Most real-world projects use fixtures and conftest.py, which require the
+> native runner's [fixtures support](https://github.com/hughhan1/rtest/issues/105) (in development).
+
+### Test Execution (`--runner pytest -n 4`)
+
+For repositories that use pytest fixtures and conftest.py, rtest can use pytest as the execution backend while still
+benefiting from fast Rust-based collection:
+
+```bash
+hyperfine --warmup 3 --min-runs 20 --max-runs 20 \
+  --command-name pytest --command-name rtest \
+  ".venv/bin/pytest -n 4 tests" \
+  ".venv/bin/rtest --runner pytest -n 4 tests"
+```
+
+| Repository | pytest | rtest | Speedup |
+|------------|--------|-------|---------|
+| [flask](https://github.com/pallets/flask) | 2.04 s ± 0.20 s | 0.91 s ± 0.11 s | **2.24x** |
+| [click](https://github.com/pallets/click) | 2.78 s ± 0.64 s | 1.12 s ± 1.30 s | **2.48x** |
+
+> **Note**: The `--runner pytest` mode uses pytest for test execution, so all pytest features (fixtures, plugins, markers)
+> work normally. The speedup comes from rtest's faster test collection phase.
 
 ## Quick Start
 

--- a/scripts/benchmark/benchmark_repositories.py
+++ b/scripts/benchmark/benchmark_repositories.py
@@ -955,9 +955,8 @@ def parse_arguments() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Examples:\n"
         "  %(prog)s --source local --list-repos\n"
-        "  %(prog)s --source 0.0.37 --repositories fastapi flask\n"
-        "  %(prog)s --source local --collect-only\n"
-        "  %(prog)s --source 0.0.37 --repositories click --collect-only",
+        "  %(prog)s --source local --repositories flask click\n"
+        "  %(prog)s --source 0.0.37 --repositories fastapi",
     )
 
     parser.add_argument(
@@ -966,9 +965,6 @@ def parse_arguments() -> argparse.Namespace:
         help="rtest source: 'local' for project root, or a version number for PyPI (e.g., '0.0.37')",
     )
     parser.add_argument("--repositories", nargs="+", help="Specific repositories to benchmark")
-    parser.add_argument(
-        "--collect-only", action="store_true", help="Run only test collection benchmarks (skip execution)"
-    )
     parser.add_argument("--list-repos", action="store_true", help="List available repositories")
     parser.add_argument(
         "--log-level", choices=["DEBUG", "INFO", "WARNING", "ERROR"], default="INFO", help="Set logging level"
@@ -1011,9 +1007,8 @@ def main() -> None:
     try:
         orchestrator = BenchmarkOrchestrator(config_path, args.source, args.debug, args.ignore_failures)
 
-        # Run benchmarks
-        benchmark_types = ["collect_only"] if args.collect_only else ["collect_only", "execution"]
-        results = orchestrator.run_benchmarks(args.repositories, benchmark_types)
+        # Run all benchmark types defined in config
+        results = orchestrator.run_benchmarks(args.repositories)
         ResultFormatter.print_summary(results)
         filename = f"benchmark_results_{int(time.time())}.json"
         output_path = orchestrator.output_dir / filename

--- a/scripts/benchmark/repositories.yml
+++ b/scripts/benchmark/repositories.yml
@@ -73,6 +73,38 @@ repositories:
       requirements_file: "requirements-tests.txt"
     python_version: "3.10"
 
+  # ===========================================================================
+  # Execution Benchmark Repositories
+  # These repos don't use pytest fixtures, making them suitable for rtest
+  # native runner execution benchmarks
+  # ===========================================================================
+
+  # more-itertools - iterator building blocks
+  # Uses hatchling backend, pure unittest.TestCase style tests
+  # No conftest.py or pytest fixtures - ideal for execution benchmarks
+  - name: "more-itertools"
+    url: "https://github.com/more-itertools/more-itertools"
+    category: "utility_library"
+    test_dir: "tests"
+    setup:
+      method: "uv_sync"
+      dependency_groups: []
+      extra_packages: []
+    python_version: "3.10"
+
+  # boltons - bags of Python utilities
+  # Uses setuptools, mostly simple class-based tests
+  # Note: Some tests use tmp_path fixture, so native runner execution fails
+  - name: "boltons"
+    url: "https://github.com/mahmoud/boltons"
+    category: "utility_library"
+    test_dir: "tests"
+    setup:
+      method: "uv_pip_install"
+      dependency_groups: []
+      extra_packages: []
+    python_version: "3.10"
+
 # Benchmark configurations
 benchmark_configs:
   collect_only:
@@ -81,6 +113,18 @@ benchmark_configs:
     rtest_args: "--collect-only"
     timeout: 300
 
+  # execution:
+  #   description: "Test execution performance"
+  #   pytest_args: ""
+  #   rtest_args: "--runner native"
+  #   timeout: 600
+
+  execution_pytest:
+    description: "Test execution with pytest runner"
+    pytest_args: "-n 4"
+    rtest_args: "--runner pytest -n 4"
+    timeout: 600
+
 # Global settings
 settings:
-  validation_timeout: 120
+  validation_timeout: 300


### PR DESCRIPTION
## Summary

- Overhaul benchmark script with per-repository configuration for different Python build systems
- Add execution benchmarks for `--runner native` and `--runner pytest -n 4`
- Add more-itertools to collection benchmarks

## Changes

**Benchmark Script:**
- Add setup method configs (uv_sync, uv_pip_install, requirements_file)
- Add `--source` argument for specifying rtest install source (local or PyPI)
- Fix result parsing to match by command name instead of position
- Remove `--collect-only` CLI flag, run all benchmark types from YAML config

**README:**
- Add more-itertools to collection benchmarks (7.39x)
- Add `--runner native` execution benchmarks (7.2x for more-itertools)
- Add `--runner pytest -n 4` execution benchmarks (2.24x flask, 2.48x click)
- Update roadmap section

**Repository Configs:**
- flask, click: uv_sync with dependency-groups
- httpx, fastapi: requirements_file method
- pydantic: uv_sync with dev group + extra packages
- more-itertools, boltons: added for benchmarks

## Notes

more-itertools cannot use `--runner pytest -n 4` due to pytest-xdist serialization limitations with Decimal objects. See #116.