### PR TITLE
fix: generate value-based parameterized test IDs for pytest compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ def test_example(value):
 **Both pytest and rtest collection show:**
 
 ```plaintext
-test_example[0]
 test_example[1]
 test_example[2]
+test_example[3]
 ```
 
 However, when parametrize arguments contain **dynamic expressions** (variables, function calls, comprehensions), `rtest`

--- a/python/rtest/mark.py
+++ b/python/rtest/mark.py
@@ -163,6 +163,20 @@ def _deduplicate_ids(ids: list[str]) -> list[str]:
     return result
 
 
+def _value_to_id_string(value: object) -> str:
+    """Convert a parameter value to its pytest-compatible string ID."""
+    if isinstance(value, str):
+        return value
+    elif value is None or isinstance(value, (int, float, bool)):
+        return str(value)
+    elif isinstance(value, (list, tuple)):
+        return "-".join(_value_to_id_string(v) for v in value)
+    elif hasattr(value, "__name__"):
+        return str(getattr(value, "__name__"))
+    else:
+        return repr(value)
+
+
 def _expand_single_spec(spec: ParametrizeSpec) -> list[ExpandedCase]:
     """Expand a single parametrize spec into ExpandedCase entries."""
     argnames = spec.argnames
@@ -174,7 +188,8 @@ def _expand_single_spec(spec: ParametrizeSpec) -> list[ExpandedCase]:
         if spec.ids is not None and i < len(spec.ids):
             raw_ids.append(spec.ids[i])
         else:
-            raw_ids.append(str(i))
+            # Generate value-based ID
+            raw_ids.append(_value_to_id_string(value))
 
     unique_ids = _deduplicate_ids(raw_ids)
 

--- a/src/python_discovery/cases.rs
+++ b/src/python_discovery/cases.rs
@@ -414,7 +414,8 @@ fn expand_single_spec(spec: &CasesSpec) -> Vec<String> {
             .chain((ids.len()..count).map(|i| i.to_string()))
             .collect()
     } else {
-        (0..count).map(|i| i.to_string()).collect()
+        // Generate value-based IDs
+        spec.argvalues.iter().map(literal_to_id_string).collect()
     }
 }
 
@@ -468,7 +469,7 @@ mod tests {
             ],
             ids: None,
         };
-        assert_eq!(expand_single_spec(&spec), vec!["0", "1", "2"]);
+        assert_eq!(expand_single_spec(&spec), vec!["1", "2", "3"]);
     }
 
     #[test]
@@ -508,7 +509,7 @@ mod tests {
         ];
         let cases = expand_cases(&specs);
         let ids: Vec<&str> = cases.iter().map(|c| c.case_id.as_str()).collect();
-        assert_eq!(ids, vec!["0-0", "0-1", "1-0", "1-1"]);
+        assert_eq!(ids, vec!["1-a", "1-b", "2-a", "2-b"]);
     }
 
     #[test]

--- a/tests/test_native_runner.py
+++ b/tests/test_native_runner.py
@@ -78,7 +78,7 @@ class TestParametrizeIntegration:
             # Check nodeids have correct format - extract param suffixes
             nodeids = [r["nodeid"] for r in single_param_results]
             suffixes = {n.split("[")[1].rstrip("]") for n in nodeids}
-            assert suffixes == {"0", "1", "2"}
+            assert suffixes == {"1", "2", "3"}
 
             # All should pass
             assert all(r["outcome"] == "passed" for r in single_param_results)
@@ -117,7 +117,7 @@ class TestParametrizeIntegration:
             # Check case IDs are cartesian product - extract param suffixes
             nodeids = [r["nodeid"] for r in stacked_results]
             suffixes = {n.split("[")[1].rstrip("]") for n in nodeids}
-            assert suffixes == {"0-0", "0-1", "1-0", "1-1"}
+            assert suffixes == {"1-10", "1-20", "2-10", "2-20"}
 
     def test_explicit_ids(self) -> None:
         """Explicit ids are used in nodeids."""


### PR DESCRIPTION
## Summary

- Parameterized test IDs now use actual parameter values instead of numeric indices
- For example, `@pytest.mark.parametrize("x", [1, 2, 3])` generates `[1]`, `[2]`, `[3]` instead of `[0]`, `[1]`, `[2]`
- Enables workflows where rtest handles discovery and pytest handles execution

## Test plan

- [x] Rust unit tests pass (`cargo test cases:: --lib`)
- [x] Python integration tests pass (`uv run pytest tests/`)
- [x] Verified value-based IDs for integers, strings, booleans, tuples
- [x] Verified deduplication still works for duplicate values

Fixes #117