### PR TITLE
fix: support generic base classes with type parameters in test collection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
   "toolChoice": "auto",
-  "automode": false
+  "automode": false,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(jq -r '.tool_input.file_path'); if [[ \"$file_path\" == *.rs ]]; then cargo fmt 2>/dev/null || true; elif [[ \"$file_path\" == *.py ]]; then uv run ruff format \"$file_path\" 2>/dev/null || true; uv run ruff check --fix \"$file_path\" 2>/dev/null || true; fi"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,13 @@
 **ALWAYS:**
 - Use `uv run` for ALL Python commands (`uv run pytest`, `uv run rtest`, `uv run python`)
 - Run `git submodule update --init` after cloning (ruff is a git submodule for AST parsing)
-- Run formatters before committing: `cargo fmt` and `uv run ruff format python/ tests/ scripts/`
 - Use conventional commits: `feat|fix|docs|test|refactor|chore: description`
 
 **NEVER:**
 - Run `pytest` or `python` directly without `uv run`
 - Use `panic!` or `unwrap()` in Rust library code—use `Result<T, E>` with proper error handling
-- Commit without running formatters (CI will fail on `cargo fmt --check` and `ruff format --check`)
+
+**Note:** Formatting is automatic via Claude hooks (`.claude/settings.json`). CI will fail on `cargo fmt --check` and `ruff format --check`.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

Test collection now correctly handles classes that inherit from parameterized generic types, such as `class TestHelper(GenericBase[MyClass])`. Previously, these patterns failed with an "unresolvable" error.

The semantic analyzer now extracts the underlying class from subscript expressions by recursively resolving the base type, matching pytest's runtime behavior. Stdlib modules like `typing.Generic` are also properly skipped during inheritance chain traversal.

Also adds a Claude hook to automatically run formatters (`cargo fmt` for Rust, `ruff format` and `ruff check --fix` for Python) after file edits, preventing CI formatting failures.

Fixes #120

## Test plan

- [x] Added integration test `test_generic_base_class_inheritance` covering parameterized generic inheritance
- [x] Verified behavior matches pytest (both collect 3 tests for the reproduction case)
- [x] All existing tests pass (96 Python tests, 90 Rust tests)