### PR TITLE
feat: add rtest.raises() context manager

### DIFF
--- a/python/rtest/__init__.py
+++ b/python/rtest/__init__.py
@@ -1,6 +1,7 @@
 """rtest - Python test runner built in Rust."""
 
 from rtest.mark import mark
+from rtest.raises import raises
 
-__all__ = ["mark"]
+__all__ = ["mark", "raises"]
 __version__ = "0.1.0"

--- a/python/rtest/raises.py
+++ b/python/rtest/raises.py
@@ -1,0 +1,88 @@
+"""rtest.raises context manager for testing expected exceptions."""
+
+from __future__ import annotations
+
+import re
+from types import TracebackType
+
+
+class RaisesContext:
+    """Context manager that asserts a block of code raises an expected exception.
+
+    Usage::
+
+        with rtest.raises(ValueError, match="invalid"):
+            int("not a number")
+    """
+
+    def __init__(
+        self,
+        expected_exception: type[BaseException] | tuple[type[BaseException], ...],
+        *,
+        match: str | re.Pattern[str] | None = None,
+    ) -> None:
+        self.expected_exception = expected_exception
+        self.match_expr = match
+        self.value: BaseException | None = None
+
+        if self.match_expr is not None:
+            try:
+                re.compile(self.match_expr)
+            except re.error as e:
+                raise ValueError(f"Invalid regex pattern provided to 'match': {e}") from e
+
+    def __enter__(self) -> RaisesContext:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        _exc_tb: TracebackType | None,
+    ) -> bool:
+        if exc_type is None:
+            expected = self.expected_exception
+            if isinstance(expected, tuple):
+                names = ", ".join(e.__name__ for e in expected)
+                raise AssertionError(f"DID NOT RAISE any of ({names})")
+            raise AssertionError(f"DID NOT RAISE {expected.__name__}")
+
+        if not issubclass(exc_type, self.expected_exception):
+            return False
+
+        if self.match_expr is not None:
+            value_str = str(exc_val)
+            if not re.search(self.match_expr, value_str):
+                raise AssertionError(
+                    f"Regex pattern did not match.\n Regex: {self.match_expr!r}\n Input: {value_str!r}"
+                ) from exc_val
+
+        self.value = exc_val
+        return True
+
+
+def raises(
+    expected_exception: type[BaseException] | tuple[type[BaseException], ...],
+    *,
+    match: str | re.Pattern[str] | None = None,
+) -> RaisesContext:
+    """Assert that a block of code raises the expected exception.
+
+    Args:
+        expected_exception: The exception type (or tuple of types) expected.
+        match: Optional regex pattern to match against the exception message.
+
+    Returns:
+        A context manager. After the ``with`` block, access the caught
+        exception via the ``.value`` attribute.
+    """
+    if isinstance(expected_exception, tuple):
+        for exc in expected_exception:
+            if not isinstance(exc, type) or not issubclass(exc, BaseException):
+                raise TypeError(f"{exc!r} is not a valid exception type")
+        if not expected_exception:
+            raise ValueError("expected_exception must not be empty")
+    elif not isinstance(expected_exception, type) or not issubclass(expected_exception, BaseException):
+        raise TypeError(f"{expected_exception!r} is not a valid exception type")
+
+    return RaisesContext(expected_exception, match=match)

--- a/test_utils/fixtures/test_raises.py
+++ b/test_utils/fixtures/test_raises.py
@@ -1,0 +1,45 @@
+"""Test fixtures for rtest.raises() integration testing."""
+
+import rtest
+
+
+def test_raises_expected():
+    with rtest.raises(ValueError):
+        raise ValueError("boom")
+
+
+def test_raises_with_match():
+    with rtest.raises(ValueError, match="bo+m"):
+        raise ValueError("boom")
+
+
+def test_raises_no_exception():
+    with rtest.raises(ValueError):
+        pass
+
+
+def test_raises_wrong_exception():
+    with rtest.raises(ValueError):
+        raise TypeError("wrong type")
+
+
+def test_raises_match_fails():
+    with rtest.raises(ValueError, match="xyz"):
+        raise ValueError("boom")
+
+
+def test_raises_value_attribute():
+    with rtest.raises(ValueError) as ctx:
+        raise ValueError("captured")
+    assert ctx.value is not None
+    assert str(ctx.value) == "captured"
+
+
+def test_raises_exception_tuple():
+    with rtest.raises((ValueError, TypeError)):
+        raise TypeError("either works")
+
+
+def test_raises_subclass():
+    with rtest.raises(Exception):
+        raise ValueError("subclass of Exception")

--- a/tests/test_native_runner.py
+++ b/tests/test_native_runner.py
@@ -271,6 +271,32 @@ class TestOutcomes:
             assert with_output[0]["stderr"].strip() == "stderr message"
 
 
+class TestRaisesIntegration:
+    def test_raises_outcomes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            output_file = tmp_path / "results.jsonl"
+            results = run_worker(
+                FIXTURES_DIR / "test_raises.py",
+                FIXTURES_DIR.parent.parent,
+                output_file,
+            )
+
+            def outcome_for(name: str) -> str:
+                matches = [r for r in results if r["nodeid"].endswith(f"::{name}")]
+                assert len(matches) == 1, f"Expected 1 result for {name}, got {len(matches)}"
+                return matches[0]["outcome"]
+
+            assert outcome_for("test_raises_expected") == "passed"
+            assert outcome_for("test_raises_with_match") == "passed"
+            assert outcome_for("test_raises_no_exception") == "failed"
+            assert outcome_for("test_raises_wrong_exception") == "error"
+            assert outcome_for("test_raises_match_fails") == "failed"
+            assert outcome_for("test_raises_value_attribute") == "passed"
+            assert outcome_for("test_raises_exception_tuple") == "passed"
+            assert outcome_for("test_raises_subclass") == "passed"
+
+
 class TestWorkerExitCode:
     """Tests for worker exit code behavior."""
 

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -1,0 +1,92 @@
+"""Unit tests for rtest.raises."""
+
+import re
+
+import rtest
+from rtest.raises import RaisesContext, raises
+
+
+class TestRaisesBasic:
+    def test_suppresses_expected_exception(self) -> None:
+        with rtest.raises(ValueError):
+            raise ValueError("expected")
+
+    def test_sets_value_attribute(self) -> None:
+        with rtest.raises(ValueError) as ctx:
+            raise ValueError("captured")
+        assert isinstance(ctx.value, ValueError)
+        assert str(ctx.value) == "captured"
+
+    def test_value_is_none_before_exit(self) -> None:
+        ctx = RaisesContext(ValueError)
+        assert ctx.value is None
+
+    def test_no_exception_raises_assertion_error(self) -> None:
+        with rtest.raises(AssertionError, match="DID NOT RAISE ValueError"):
+            with rtest.raises(ValueError):
+                pass
+
+    def test_wrong_exception_propagates(self) -> None:
+        with rtest.raises(TypeError):
+            with rtest.raises(ValueError):
+                raise TypeError("wrong")
+
+
+class TestRaisesMatch:
+    def test_match_succeeds(self) -> None:
+        with rtest.raises(ValueError, match="boom"):
+            raise ValueError("big boom")
+
+    def test_match_uses_re_search(self) -> None:
+        with rtest.raises(ValueError, match="oo"):
+            raise ValueError("boom")
+
+    def test_match_regex_pattern(self) -> None:
+        with rtest.raises(ValueError, match=r"value \d+"):
+            raise ValueError("invalid value 42")
+
+    def test_match_fails_raises_assertion_error(self) -> None:
+        with rtest.raises(AssertionError, match="Regex pattern did not match"):
+            with rtest.raises(ValueError, match="xyz"):
+                raise ValueError("boom")
+
+    def test_invalid_regex_raises_immediately(self) -> None:
+        with rtest.raises(ValueError, match="Invalid regex pattern"):
+            raises(ValueError, match="[invalid")
+
+    def test_compiled_pattern(self) -> None:
+        pattern = re.compile(r"bo+m")
+        with rtest.raises(ValueError, match=pattern):
+            raise ValueError("boom")
+
+
+class TestRaisesExceptionTypes:
+    def test_tuple_of_exceptions(self) -> None:
+        with rtest.raises((ValueError, TypeError)):
+            raise TypeError("either")
+
+    def test_subclass_matching(self) -> None:
+        with rtest.raises(Exception):
+            raise ValueError("subclass")
+
+    def test_base_exception(self) -> None:
+        with rtest.raises(KeyboardInterrupt):
+            raise KeyboardInterrupt
+
+
+class TestRaisesValidation:
+    def test_rejects_non_exception_type(self) -> None:
+        with rtest.raises(TypeError, match="is not a valid exception type"):
+            raises(str)  # type: ignore[arg-type]
+
+    def test_rejects_non_type(self) -> None:
+        with rtest.raises(TypeError, match="is not a valid exception type"):
+            raises(42)  # type: ignore[arg-type]
+
+    def test_rejects_empty_tuple(self) -> None:
+        with rtest.raises(ValueError, match="must not be empty"):
+            raises(())
+
+    def test_rejects_invalid_type_in_tuple(self) -> None:
+        with rtest.raises(TypeError, match="is not a valid exception type"):
+            raises((ValueError, str))  # type: ignore[arg-type]


### PR DESCRIPTION
- Adds `rtest.raises()` as a context manager for testing expected exceptions in the native runner
- API matches `pytest.raises` — supports exception types (including tuples/subclasses), optional `match` regex, and `.value` attribute
- Closes #108