### PR TITLE
feat: add coordinator-side test selection (-k, --lf, --ff)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtest"
-version = "0.0.40"
+version = "0.0.46"
 dependencies = [
  "clap",
  "glob",

--- a/python/rtest/worker/__main__.py
+++ b/python/rtest/worker/__main__.py
@@ -42,6 +42,12 @@ def main() -> int:
         help="Glob patterns for test function/method names using fnmatch syntax (default: test*)",
     )
     parser.add_argument(
+        "--nodeids-file",
+        type=Path,
+        default=None,
+        help="Optional file listing nodeids to run (one per line); omit to run all discovered tests",
+    )
+    parser.add_argument(
         "files",
         nargs="+",
         type=Path,
@@ -56,6 +62,7 @@ def main() -> int:
     test_files: list[Path] = args.files
     python_classes: list[str] = args.python_classes
     python_functions: list[str] = args.python_functions
+    nodeids_file: Path | None = args.nodeids_file
 
     return run_tests(
         root=root,
@@ -63,6 +70,7 @@ def main() -> int:
         test_files=test_files,
         python_classes=python_classes,
         python_functions=python_functions,
+        nodeids_file=nodeids_file,
     )
 
 

--- a/python/rtest/worker/runner.py
+++ b/python/rtest/worker/runner.py
@@ -250,12 +250,23 @@ def _run_single_test(test_case: TestCase) -> TestResult:
     )
 
 
+def _load_selected_nodeids(path: Path) -> set[str]:
+    """Load coordinator-selected nodeids (one per line)."""
+    selected: set[str] = set()
+    for line in path.read_text().splitlines():
+        nodeid = line.strip()
+        if nodeid:
+            selected.add(nodeid)
+    return selected
+
+
 def run_tests(
     root: Path,
     output_file: Path,
     test_files: list[Path],
     python_classes: list[str] | None = None,
     python_functions: list[str] | None = None,
+    nodeids_file: Path | None = None,
 ) -> int:
     """Run tests from the given files and write results to JSONL.
 
@@ -310,6 +321,10 @@ def run_tests(
                     error_type=type(e).__name__,
                 )
             )
+
+    if nodeids_file is not None:
+        selected_nodeids = _load_selected_nodeids(nodeids_file)
+        all_test_cases = [tc for tc in all_test_cases if tc.nodeid in selected_nodeids]
 
     all_test_cases.sort(key=lambda tc: tc.nodeid)
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,318 @@
+//! Pytest-compatible failure cache (`.pytest_cache/v/cache/lastfailed`).
+
+use crate::collection_integration::CollectedItem;
+use regex::Regex;
+use serde_json::{Map, Value};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LastFailedMode {
+    #[default]
+    None,
+    LastFailed,
+    FailedFirst,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LastFailedNoFailures {
+    #[default]
+    All,
+    None,
+}
+
+impl std::str::FromStr for LastFailedNoFailures {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(Self::All),
+            "none" => Ok(Self::None),
+            other => Err(format!(
+                "invalid --lfnf value: {other} (choose 'all' or 'none')"
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CacheError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    InvalidFormat(String),
+}
+
+impl std::fmt::Display for CacheError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CacheError::Io(e) => write!(f, "cache I/O error: {e}"),
+            CacheError::Json(e) => write!(f, "cache JSON error: {e}"),
+            CacheError::InvalidFormat(msg) => write!(f, "cache format error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CacheError {}
+
+impl From<std::io::Error> for CacheError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for CacheError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
+    }
+}
+
+pub fn cache_dir_for_root(root: &Path, configured: Option<&PathBuf>) -> PathBuf {
+    configured
+        .cloned()
+        .unwrap_or_else(|| root.join(".pytest_cache"))
+}
+
+fn lastfailed_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join("v").join("cache").join("lastfailed")
+}
+
+pub fn read_lastfailed(cache_dir: &Path) -> Result<HashSet<String>, CacheError> {
+    let path = lastfailed_path(cache_dir);
+    if !path.exists() {
+        return Ok(HashSet::new());
+    }
+    let content = fs::read_to_string(&path)?;
+    let value: Value = serde_json::from_str(&content)?;
+    let obj = value
+        .as_object()
+        .ok_or_else(|| CacheError::InvalidFormat("lastfailed is not a JSON object".into()))?;
+    Ok(obj.keys().cloned().collect())
+}
+
+pub fn write_lastfailed(cache_dir: &Path, failed: &HashSet<String>) -> Result<(), CacheError> {
+    let path = lastfailed_path(cache_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut map = Map::new();
+    for key in failed {
+        map.insert(key.clone(), Value::Bool(true));
+    }
+    let content = serde_json::to_string_pretty(&Value::Object(map))?;
+    fs::write(path, content)?;
+    Ok(())
+}
+
+pub fn clear_cache(cache_dir: &Path) -> Result<(), CacheError> {
+    let path = lastfailed_path(cache_dir);
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+pub fn apply_last_failed(
+    items: Vec<CollectedItem>,
+    mode: LastFailedMode,
+    lfnf: LastFailedNoFailures,
+    cache_dir: &Path,
+) -> Result<Vec<CollectedItem>, CacheError> {
+    match mode {
+        LastFailedMode::None => Ok(items),
+        LastFailedMode::LastFailed => {
+            let lastfailed = read_lastfailed(cache_dir)?;
+            if lastfailed.is_empty() {
+                return match lfnf {
+                    LastFailedNoFailures::All => Ok(items),
+                    LastFailedNoFailures::None => Ok(vec![]),
+                };
+            }
+            let filtered: Vec<_> = items
+                .into_iter()
+                .filter(|item| lastfailed.contains(&item.nodeid))
+                .collect();
+            if !filtered.is_empty() {
+                println!(
+                    "run-last-failure: rerun previous {} failure(s)",
+                    filtered.len()
+                );
+            }
+            Ok(filtered)
+        }
+        LastFailedMode::FailedFirst => apply_failed_first(items, cache_dir),
+    }
+}
+
+pub fn apply_failed_first(
+    items: Vec<CollectedItem>,
+    cache_dir: &Path,
+) -> Result<Vec<CollectedItem>, CacheError> {
+    let lastfailed = read_lastfailed(cache_dir)?;
+    if lastfailed.is_empty() {
+        return Ok(items);
+    }
+    let mut failed_first = Vec::new();
+    let mut rest = Vec::new();
+    for item in items {
+        if lastfailed.contains(&item.nodeid) {
+            failed_first.push(item);
+        } else {
+            rest.push(item);
+        }
+    }
+    if !failed_first.is_empty() {
+        println!(
+            "run-last-failure: rerun previous {} failure(s) first",
+            failed_first.len()
+        );
+    }
+    failed_first.extend(rest);
+    Ok(failed_first)
+}
+
+/// Update `lastfailed` from structured test outcomes (coordinator-owned for all runners).
+pub fn update_lastfailed_from_outcomes(
+    cache_dir: &Path,
+    outcomes: &[(String, TestOutcome)],
+) -> Result<(), CacheError> {
+    let mut lastfailed = read_lastfailed(cache_dir)?;
+    for (nodeid, outcome) in outcomes {
+        match outcome {
+            TestOutcome::Failed | TestOutcome::Error => {
+                lastfailed.insert(nodeid.clone());
+            }
+            TestOutcome::Passed | TestOutcome::Skipped => {
+                lastfailed.remove(nodeid);
+            }
+        }
+    }
+    write_lastfailed(cache_dir, &lastfailed)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestOutcome {
+    Passed,
+    Failed,
+    Skipped,
+    Error,
+}
+
+static TESTCASE_OPEN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"<testcase\s+([^>]+?)(\s*/>|\s*>)"#).expect("valid regex"));
+static ATTR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(\w+)="([^"]*)""#).expect("valid regex"));
+
+fn junit_nodeid(classname: &str, name: &str) -> String {
+    if classname.is_empty() {
+        name.to_string()
+    } else {
+        format!("{classname}::{name}")
+    }
+}
+
+fn junit_outcome(fragment: &str) -> TestOutcome {
+    if fragment.contains("<failure") || fragment.contains("<error") {
+        if fragment.contains("<error") {
+            TestOutcome::Error
+        } else {
+            TestOutcome::Failed
+        }
+    } else if fragment.contains("<skipped") {
+        TestOutcome::Skipped
+    } else {
+        TestOutcome::Passed
+    }
+}
+
+/// Parse pytest `--junitxml` output into nodeid/outcome pairs.
+pub fn parse_junit_xml(path: &Path) -> Result<Vec<(String, TestOutcome)>, CacheError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(path)?;
+    let mut outcomes = Vec::new();
+
+    for caps in TESTCASE_OPEN.captures_iter(&content) {
+        let attrs = &caps[1];
+        let self_closing = caps[2].contains('/');
+
+        let mut classname = String::new();
+        let mut name = String::new();
+        for attr in ATTR.captures_iter(attrs) {
+            match &attr[1] {
+                "classname" => classname = attr[2].to_string(),
+                "name" => name = attr[2].to_string(),
+                _ => {}
+            }
+        }
+        if name.is_empty() {
+            continue;
+        }
+
+        let nodeid = junit_nodeid(&classname, &name);
+        let start = caps.get(0).map(|m| m.end()).unwrap_or(0);
+        let fragment = if self_closing {
+            String::new()
+        } else {
+            let rest = &content[start..];
+            rest.split("</testcase>").next().unwrap_or(rest).to_string()
+        };
+        outcomes.push((nodeid, junit_outcome(&fragment)));
+    }
+
+    Ok(outcomes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lastfailed_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = dir.path().join(".pytest_cache");
+        let mut failed = HashSet::new();
+        failed.insert("test_foo.py::test_bar".into());
+        write_lastfailed(&cache_dir, &failed).unwrap();
+        let read = read_lastfailed(&cache_dir).unwrap();
+        assert!(read.contains("test_foo.py::test_bar"));
+    }
+
+    #[test]
+    fn test_parse_junit_xml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("results.xml");
+        fs::write(
+            &path,
+            r#"<?xml version="1.0" encoding="utf-8"?>
+<testsuite>
+  <testcase classname="tests/test_a.py" name="test_x" time="0.01"/>
+  <testcase classname="tests/test_a.py" name="test_y" time="0.01"><failure message="fail"/></testcase>
+</testsuite>"#,
+        )
+        .unwrap();
+        let outcomes = parse_junit_xml(&path).unwrap();
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes
+            .iter()
+            .any(|(n, o)| n == "tests/test_a.py::test_x" && *o == TestOutcome::Passed));
+        assert!(outcomes
+            .iter()
+            .any(|(n, o)| n == "tests/test_a.py::test_y" && *o == TestOutcome::Failed));
+    }
+
+    #[test]
+    fn test_lfnf_parse() {
+        assert_eq!(
+            "all".parse::<LastFailedNoFailures>().unwrap(),
+            LastFailedNoFailures::All
+        );
+        assert_eq!(
+            "none".parse::<LastFailedNoFailures>().unwrap(),
+            LastFailedNoFailures::None
+        );
+        assert!("invalid".parse::<LastFailedNoFailures>().is_err());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,30 @@ pub struct Args {
     #[arg(long)]
     pub collect_only: bool,
 
+    /// Only run tests matching the keyword expression
+    #[arg(short = 'k', value_name = "EXPRESSION")]
+    pub keyword_expr: Option<String>,
+
+    /// Run only tests that failed in the last run
+    #[arg(long = "lf", alias = "last-failed", conflicts_with = "failed_first")]
+    pub last_failed: bool,
+
+    /// Run failed tests first, then the rest
+    #[arg(long = "ff", alias = "failed-first", conflicts_with = "last_failed")]
+    pub failed_first: bool,
+
+    /// Behavior when `--lf` finds no failures: `all` (default) or `none`
+    #[arg(
+        long = "lfnf",
+        alias = "last-failed-no-failures",
+        default_value = "all"
+    )]
+    pub lfnf: String,
+
+    /// Clear the failure cache before running tests
+    #[arg(long = "cache-clear")]
+    pub cache_clear: bool,
+
     /// Test runner backend
     #[arg(long, value_enum, default_value = "pytest")]
     pub runner: Runner,
@@ -212,5 +236,17 @@ mod tests {
 
         let args = Args::parse_from(["rtest", "--runner", "pytest"]);
         assert!(matches!(args.runner, Runner::Pytest));
+    }
+
+    #[test]
+    fn test_cli_parsing_with_keyword_and_last_failed() {
+        let args = Args::parse_from(["rtest", "-k", "foo and not bar"]);
+        assert_eq!(args.keyword_expr.as_deref(), Some("foo and not bar"));
+
+        let err = Args::try_parse_from(["rtest", "--lf", "--ff"]);
+        assert!(err.is_err());
+
+        let args = Args::parse_from(["rtest", "--cache-clear"]);
+        assert!(args.cache_clear);
     }
 }

--- a/src/collection/nodes.rs
+++ b/src/collection/nodes.rs
@@ -24,10 +24,29 @@ pub struct Session {
 
 impl Session {
     pub fn new(rootpath: PathBuf) -> Self {
+        let mut config = CollectionConfig::default();
+        let pytest_config = crate::config::read_pytest_config(&rootpath);
+        if !pytest_config.python_files.is_empty() {
+            config.python_files = pytest_config.python_files;
+        }
+        if !pytest_config.python_classes.is_empty() {
+            config.python_classes = pytest_config.python_classes;
+        }
+        if !pytest_config.python_functions.is_empty() {
+            config.python_functions = pytest_config.python_functions;
+        }
+        if !pytest_config.testpaths.is_empty() {
+            config.testpaths = pytest_config
+                .testpaths
+                .iter()
+                .map(|p| rootpath.join(p))
+                .collect();
+        }
+
         Self {
             nodeid: String::new(),
             rootpath,
-            config: CollectionConfig::default(),
+            config,
             cache: HashMap::new(),
         }
     }
@@ -331,6 +350,7 @@ pub struct Function {
     #[allow(dead_code)]
     pub name: String,
     pub nodeid: String,
+    pub keywords: Vec<String>,
     pub location: Location,
 }
 
@@ -354,6 +374,10 @@ impl Collector for Function {
 
     fn is_item(&self) -> bool {
         true
+    }
+
+    fn keywords(&self) -> &[String] {
+        &self.keywords
     }
 }
 

--- a/src/collection/types.rs
+++ b/src/collection/types.rs
@@ -36,4 +36,9 @@ pub trait Collector: std::fmt::Debug {
     fn is_item(&self) -> bool {
         false
     }
+
+    /// Keyword names for `-k` expression matching (empty for non-items).
+    fn keywords(&self) -> &[String] {
+        &[]
+    }
 }

--- a/src/collection_integration.rs
+++ b/src/collection_integration.rs
@@ -6,6 +6,25 @@ use crate::collection::types::Collector;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+/// A collected test item with metadata for post-collection selection.
+#[derive(Debug, Clone)]
+pub struct CollectedItem {
+    pub nodeid: String,
+    pub keywords: Vec<String>,
+}
+
+impl CollectedItem {
+    pub fn nodeids(items: &[Self]) -> Vec<String> {
+        items.iter().map(|item| item.nodeid.clone()).collect()
+    }
+}
+
+/// Summary counts for collection display when selection filters items.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CollectionDisplayStats {
+    pub deselected: usize,
+}
+
 /// Holds errors and warnings encountered during collection
 #[derive(Debug)]
 pub struct CollectionErrors {
@@ -13,11 +32,11 @@ pub struct CollectionErrors {
     pub warnings: Vec<CollectionWarning>,
 }
 
-/// Run the Rust-based collection and return test node IDs
+/// Run the Rust-based collection and return test items
 pub fn collect_tests_rust(
     rootpath: PathBuf,
     args: &[String],
-) -> Result<(Vec<String>, CollectionErrors), CollectionError> {
+) -> Result<(Vec<CollectedItem>, CollectionErrors), CollectionError> {
     let session = Rc::new(Session::new(rootpath));
     let mut collection_errors = CollectionErrors {
         errors: Vec::new(),
@@ -30,17 +49,17 @@ pub fn collect_tests_rust(
                 collection_errors.errors.push((path, error));
             }
 
-            let mut test_nodes = Vec::new();
+            let mut test_items = Vec::new();
 
             for collector in collectors {
                 collect_items_recursive(
                     collector.as_ref(),
-                    &mut test_nodes,
+                    &mut test_items,
                     &mut collection_errors,
                 );
             }
 
-            Ok((test_nodes, collection_errors))
+            Ok((test_items, collection_errors))
         }
         Err(e) => Err(e),
     }
@@ -49,18 +68,21 @@ pub fn collect_tests_rust(
 /// Recursively collect all test items
 fn collect_items_recursive(
     collector: &dyn Collector,
-    test_nodes: &mut Vec<String>,
+    test_items: &mut Vec<CollectedItem>,
     collection_errors: &mut CollectionErrors,
 ) {
     if collector.is_item() {
-        test_nodes.push(collector.nodeid().into());
+        test_items.push(CollectedItem {
+            nodeid: collector.nodeid().to_string(),
+            keywords: collector.keywords().to_vec(),
+        });
     } else {
         let report = collect_one_node(collector);
         collection_errors.warnings.extend(report.warnings);
         match report.outcome {
             CollectionOutcome::Passed => {
                 for child in report.result {
-                    collect_items_recursive(child.as_ref(), test_nodes, collection_errors);
+                    collect_items_recursive(child.as_ref(), test_items, collection_errors);
                 }
             }
             CollectionOutcome::Failed => {
@@ -76,7 +98,11 @@ fn collect_items_recursive(
 }
 
 /// Display collection results in a format similar to pytest
-pub fn display_collection_results(test_nodes: &[String], errors: &CollectionErrors) {
+pub fn display_collection_results(
+    test_items: &[CollectedItem],
+    errors: &CollectionErrors,
+    stats: CollectionDisplayStats,
+) {
     // ANSI color codes
     const RED: &str = "\x1b[31m";
     const BOLD_RED: &str = "\x1b[1;31m";
@@ -116,21 +142,29 @@ pub fn display_collection_results(test_nodes: &[String], errors: &CollectionErro
         );
     }
 
-    let item_count = test_nodes.len();
+    let item_count = test_items.len();
     let error_count = errors.errors.len();
     let warning_count = errors.warnings.len();
 
-    if item_count == 0 && error_count == 0 {
+    if item_count == 0 && error_count == 0 && stats.deselected == 0 {
         println!("No tests collected.");
     } else {
         let mut summary_parts = Vec::new();
 
-        if item_count > 0 {
+        if item_count > 0 || stats.deselected > 0 {
             summary_parts.push(format!(
                 "collected {} item{}",
-                item_count,
-                if item_count == 1 { "" } else { "s" }
+                item_count + stats.deselected,
+                if item_count + stats.deselected == 1 {
+                    ""
+                } else {
+                    "s"
+                }
             ));
+        }
+
+        if stats.deselected > 0 {
+            summary_parts.push(format!("{} deselected", stats.deselected));
         }
 
         if error_count > 0 {
@@ -153,10 +187,10 @@ pub fn display_collection_results(test_nodes: &[String], errors: &CollectionErro
             println!("{}", summary_parts.join(" / "));
         }
 
-        if !test_nodes.is_empty() {
+        if !test_items.is_empty() {
             println!();
-            for node in test_nodes {
-                println!("  {node}");
+            for item in test_items {
+                println!("  {}", item.nodeid);
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct PytestConfig {
     pub python_classes: Vec<String>,
     /// Patterns for test function/method names (e.g., "test*")
     pub python_functions: Vec<String>,
+    /// Pytest cache directory (e.g. `.pytest_cache`)
+    pub cache_dir: Option<PathBuf>,
 }
 
 /// Read pytest configuration from pyproject.toml
@@ -104,6 +106,14 @@ pub fn read_pytest_config(root_path: &Path) -> PytestConfig {
             "Found python_functions in pyproject.toml: {:?}",
             config.python_functions
         );
+    }
+
+    if let Some(cache_dir) = ini_options
+        .and_then(|i| i.get("cache_dir"))
+        .and_then(|v| v.as_str())
+    {
+        config.cache_dir = Some(PathBuf::from(cache_dir));
+        debug!("Found cache_dir in pyproject.toml: {:?}", config.cache_dir);
     }
 
     config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! rtest core library for Python test collection and execution.
 
+pub mod cache;
 pub mod cli;
 pub mod collection;
 pub mod collection_integration;
@@ -11,20 +12,28 @@ pub mod pytest_executor;
 pub mod python_discovery;
 pub mod runner;
 pub mod scheduler;
+pub mod selection;
+pub mod session;
 pub mod subproject;
 pub mod utils;
 pub mod worker;
 
 pub use collection::error::{CollectionError, CollectionResult};
-pub use collection_integration::{collect_tests_rust, display_collection_results};
+pub use collection_integration::{
+    collect_tests_rust, display_collection_results, CollectedItem, CollectionDisplayStats,
+    CollectionErrors,
+};
 pub use native_runner::{
     collect_test_files, default_python_classes, default_python_files, default_python_functions,
-    execute_native, NativeRunnerConfig,
+    execute_native, files_from_nodeids, NativeExecutionResult, NativeRunnerConfig,
 };
 #[cfg(feature = "extension-module")]
 pub use pyo3::_rtest;
-pub use pytest_executor::execute_tests;
-pub use runner::{execute_tests_parallel, ParallelExecutionConfig, PytestRunner};
+pub use pytest_executor::{execute_tests, execute_tests_exit_code, PytestExecutionResult};
+pub use runner::{
+    execute_tests_parallel, execute_tests_parallel_with_outcomes, ParallelExecutionConfig,
+    PytestRunner,
+};
 pub use scheduler::{create_scheduler, DistributionMode};
 pub use utils::determine_worker_count;
 pub use worker::{WorkerPool, WorkerTask};

--- a/src/native_runner.rs
+++ b/src/native_runner.rs
@@ -1,6 +1,8 @@
 //! Native test runner that executes tests via Python workers.
 
+use crate::cache::TestOutcome;
 use crate::collection::glob_match;
+use crate::collection_integration::CollectedItem;
 use serde::Deserialize;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -51,6 +53,8 @@ pub struct NativeRunnerConfig {
     pub python_files: Vec<String>,
     pub python_classes: Vec<String>,
     pub python_functions: Vec<String>,
+    /// When non-empty, workers only execute tests with these nodeids.
+    pub selected_nodeids: Vec<String>,
 }
 
 /// Default pytest python_files patterns
@@ -195,50 +199,62 @@ fn print_summary(results: &AggregatedResults) {
     );
 }
 
-fn run_worker(
+fn write_nodeids_file(path: &Path, nodeids: &[String]) -> Result<(), String> {
+    let content = nodeids.join("\n");
+    std::fs::write(path, content).map_err(|e| format!("Failed to write nodeids file: {e}"))
+}
+
+struct WorkerInvocation<'a> {
     worker_id: usize,
-    python: &str,
-    root: &Path,
-    output_file: &Path,
-    files: &[PathBuf],
-    python_classes: &[String],
-    python_functions: &[String],
-) -> Result<(), String> {
-    let mut cmd = Command::new(python);
+    python: &'a str,
+    root: &'a Path,
+    output_file: &'a Path,
+    files: &'a [PathBuf],
+    python_classes: &'a [String],
+    python_functions: &'a [String],
+    nodeids_file: Option<&'a Path>,
+}
+
+fn run_worker(task: &WorkerInvocation<'_>) -> Result<(), String> {
+    let mut cmd = Command::new(task.python);
     cmd.arg("-m")
         .arg("rtest.worker")
         .arg("--root")
-        .arg(root)
+        .arg(task.root)
         .arg("--out")
-        .arg(output_file);
+        .arg(task.output_file);
 
-    if !python_classes.is_empty() {
+    if !task.python_classes.is_empty() {
         cmd.arg("--python-classes");
-        for pattern in python_classes {
+        for pattern in task.python_classes {
             cmd.arg(pattern);
         }
     }
 
-    if !python_functions.is_empty() {
+    if !task.python_functions.is_empty() {
         cmd.arg("--python-functions");
-        for pattern in python_functions {
+        for pattern in task.python_functions {
             cmd.arg(pattern);
         }
+    }
+
+    if let Some(path) = task.nodeids_file {
+        cmd.arg("--nodeids-file").arg(path);
     }
 
     // Use -- to separate options from positional file arguments
     cmd.arg("--");
-    for file in files {
+    for file in task.files {
         cmd.arg(file);
     }
 
-    cmd.current_dir(root)
+    cmd.current_dir(task.root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
     let output = cmd
         .output()
-        .map_err(|e| format!("Worker {} failed to start: {}", worker_id, e))?;
+        .map_err(|e| format!("Worker {} failed to start: {}", task.worker_id, e))?;
 
     // Check worker exit code - non-zero indicates test failures or errors
     if !output.status.success() {
@@ -249,12 +265,12 @@ fn run_worker(
             if !output.stderr.is_empty() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 if !stderr.trim().is_empty() {
-                    eprintln!("Worker {} stderr:\n{}", worker_id, stderr);
+                    eprintln!("Worker {} stderr:\n{}", task.worker_id, stderr);
                 }
             }
             return Err(format!(
                 "Worker {} crashed with exit code {} (expected 0 or 1)",
-                worker_id, exit_code
+                task.worker_id, exit_code
             ));
         }
     }
@@ -262,10 +278,40 @@ fn run_worker(
     Ok(())
 }
 
-pub fn execute_native(config: &NativeRunnerConfig, test_files: Vec<PathBuf>) -> i32 {
+pub struct NativeExecutionResult {
+    pub exit_code: i32,
+    pub outcomes: Vec<(String, TestOutcome)>,
+}
+
+/// Derive unique test file paths from collected nodeids (file prefix before `::`).
+pub fn files_from_nodeids(root: &Path, items: &[CollectedItem]) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = items
+        .iter()
+        .filter_map(|item| {
+            let file_part = item.nodeid.split("::").next()?;
+            let path = Path::new(file_part);
+            if path.is_absolute() {
+                Some(path.to_path_buf())
+            } else {
+                Some(root.join(file_part))
+            }
+        })
+        .collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
+pub fn execute_native(
+    config: &NativeRunnerConfig,
+    test_files: Vec<PathBuf>,
+) -> NativeExecutionResult {
     if test_files.is_empty() {
         println!("No test files to run.");
-        return 0;
+        return NativeExecutionResult {
+            exit_code: 0,
+            outcomes: vec![],
+        };
     }
 
     let num_workers = config.num_workers.max(1);
@@ -279,8 +325,25 @@ pub fn execute_native(config: &NativeRunnerConfig, test_files: Vec<PathBuf>) -> 
         Ok(dir) => dir,
         Err(e) => {
             eprintln!("Failed to create temp directory: {}", e);
-            return 1;
+            return NativeExecutionResult {
+                exit_code: 1,
+                outcomes: vec![],
+            };
         }
+    };
+
+    let nodeids_file = if config.selected_nodeids.is_empty() {
+        None
+    } else {
+        let path = temp_dir.path().join("selected-nodeids.txt");
+        if let Err(e) = write_nodeids_file(&path, &config.selected_nodeids) {
+            eprintln!("Failed to write selected nodeids: {e}");
+            return NativeExecutionResult {
+                exit_code: 1,
+                outcomes: vec![],
+            };
+        }
+        Some(path)
     };
 
     let shards = shard_files(test_files, num_workers);
@@ -295,16 +358,19 @@ pub fn execute_native(config: &NativeRunnerConfig, test_files: Vec<PathBuf>) -> 
         let output_file = output_file.clone();
         let python_classes = config.python_classes.clone();
         let python_functions = config.python_functions.clone();
+        let nodeids_file = nodeids_file.clone();
         let handle = thread::spawn(move || {
-            run_worker(
-                i,
-                &python,
-                &root,
-                &output_file,
-                &shard,
-                &python_classes,
-                &python_functions,
-            )
+            let task = WorkerInvocation {
+                worker_id: i,
+                python: &python,
+                root: &root,
+                output_file: &output_file,
+                files: &shard,
+                python_classes: &python_classes,
+                python_functions: &python_functions,
+                nodeids_file: nodeids_file.as_deref(),
+            };
+            run_worker(&task)
         });
         handles.push(handle);
     }
@@ -332,15 +398,33 @@ pub fn execute_native(config: &NativeRunnerConfig, test_files: Vec<PathBuf>) -> 
         }
     }
 
+    let outcomes: Vec<(String, TestOutcome)> = all_results
+        .iter()
+        .flatten()
+        .map(|result| {
+            let outcome = match result.outcome.as_str() {
+                "passed" => TestOutcome::Passed,
+                "failed" => TestOutcome::Failed,
+                "skipped" => TestOutcome::Skipped,
+                "error" => TestOutcome::Error,
+                _ => TestOutcome::Error,
+            };
+            (result.nodeid.clone(), outcome)
+        })
+        .collect();
+
     let aggregated = aggregate_results(all_results);
     print_summary(&aggregated);
 
-    // TempDir is automatically cleaned up when dropped
-
-    if aggregated.failed > 0 || aggregated.error > 0 || !worker_errors.is_empty() {
+    let exit_code = if aggregated.failed > 0 || aggregated.error > 0 || !worker_errors.is_empty() {
         1
     } else {
         0
+    };
+
+    NativeExecutionResult {
+        exit_code,
+        outcomes,
     }
 }
 

--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -1,91 +1,19 @@
 //! Python bindings for rtest library.
 
-use clap::Parser;
+use clap::{error::ErrorKind, Parser};
 use pyo3::prelude::*;
 use std::env;
 use std::path::PathBuf;
 
-use crate::cli::{exit_codes, Args, Runner};
-use crate::collection::error::CollectionError;
-use crate::config::read_pytest_config;
-use crate::{
-    collect_test_files, collect_tests_rust, default_python_classes, default_python_files,
-    default_python_functions, determine_worker_count, display_collection_results, execute_native,
-    execute_tests, execute_tests_parallel, subproject, NativeRunnerConfig, ParallelExecutionConfig,
-};
+use crate::cli::{exit_codes, Args};
+use crate::runner::PytestRunner;
+use crate::session::{run_session, SessionContext};
+use crate::utils::determine_worker_count;
 
-/// Get the current working directory, returning an error message on failure.
 fn get_current_dir() -> Result<PathBuf, String> {
     env::current_dir().map_err(|e| format!("Failed to get current directory: {e}"))
 }
 
-fn handle_collection_error(e: CollectionError) -> ! {
-    match e {
-        CollectionError::FileNotFound(path) => {
-            eprintln!("ERROR: file or directory not found: {}", path.display());
-            std::process::exit(exit_codes::USAGE_ERROR);
-        }
-        e => {
-            eprintln!("FATAL: {e}");
-            std::process::exit(exit_codes::TESTS_FAILED);
-        }
-    }
-}
-
-pub struct PytestRunner {
-    pub program: String,
-    pub initial_args: Vec<String>,
-    pub env_vars: Vec<(String, String)>,
-}
-
-impl PytestRunner {
-    pub fn from_current_python(py: Python) -> Self {
-        let python_path = py
-            .import("sys")
-            .and_then(|sys| sys.getattr("executable"))
-            .and_then(|exe| exe.extract::<String>())
-            .unwrap_or_else(|_| "python3".to_string());
-
-        let initial_args = vec!["-m".to_string(), "pytest".to_string()];
-
-        Self {
-            program: python_path,
-            initial_args,
-            env_vars: vec![],
-        }
-    }
-
-    pub fn from_current_python_with_env(py: Python, env_vars: Vec<String>) -> Self {
-        let python_path = py
-            .import("sys")
-            .and_then(|sys| sys.getattr("executable"))
-            .and_then(|exe| exe.extract::<String>())
-            .unwrap_or_else(|_| "python3".to_string());
-
-        let initial_args = vec!["-m".to_string(), "pytest".to_string()];
-
-        // Parse environment variables from KEY=VALUE format
-        let parsed_env_vars: Vec<(String, String)> = env_vars
-            .iter()
-            .filter_map(|env_str| {
-                if let Some((key, value)) = env_str.split_once('=') {
-                    Some((key.to_string(), value.to_string()))
-                } else {
-                    eprintln!("Warning: Invalid environment variable format: {}", env_str);
-                    None
-                }
-            })
-            .collect();
-
-        Self {
-            program: python_path,
-            initial_args,
-            env_vars: parsed_env_vars,
-        }
-    }
-}
-
-/// Get the current Python executable path from sys.executable
 fn get_python_executable(py: Python) -> String {
     py.import("sys")
         .and_then(|sys| sys.getattr("executable"))
@@ -93,87 +21,36 @@ fn get_python_executable(py: Python) -> String {
         .unwrap_or_else(|_| "python3".to_string())
 }
 
-#[pyfunction]
-#[pyo3(signature = (pytest_args=None))]
-fn run_tests(py: Python, pytest_args: Option<Vec<String>>) -> i32 {
-    let pytest_args = pytest_args.unwrap_or_default();
-
-    // Use the current Python executable
-    let runner = PytestRunner::from_current_python(py);
-
-    // Determine root path: if the first argument is a path and not a pytest flag, use it
-    let (rootpath, filtered_args) = if let Some(first_arg) = pytest_args.first() {
-        if !first_arg.starts_with('-') && std::path::Path::new(first_arg).exists() {
-            // First argument is a path, use it as root and remove it from pytest args
-            let path = PathBuf::from(first_arg);
-            let remaining_args = pytest_args.into_iter().skip(1).collect();
-            (path, remaining_args)
-        } else {
-            // First argument is not a path, use current directory
-            match get_current_dir() {
-                Ok(dir) => (dir, pytest_args),
-                Err(e) => {
-                    eprintln!("{e}");
-                    return 1;
-                }
-            }
-        }
-    } else {
-        match get_current_dir() {
-            Ok(dir) => (dir, pytest_args),
-            Err(e) => {
-                eprintln!("{e}");
-                return 1;
-            }
-        }
-    };
-
-    let collection_result = collect_tests_rust(rootpath.clone(), &filtered_args);
-
-    let (test_nodes, errors) = match collection_result {
-        Ok((nodes, errs)) => (nodes, errs),
-        Err(e) => handle_collection_error(e),
-    };
-
-    display_collection_results(&test_nodes, &errors);
-
-    // Exit early if there are collection errors
-    if !errors.errors.is_empty() {
-        return exit_codes::TESTS_FAILED;
-    }
-
-    if test_nodes.is_empty() {
-        println!("No tests found.");
-        return 0;
-    }
-
-    execute_tests(
-        &runner.program,
-        &runner.initial_args,
-        test_nodes,
-        filtered_args,
-        Some(&rootpath),
-        &runner.env_vars,
-    )
-}
-
-#[pyfunction]
-fn main_cli_with_args(py: Python, argv: Vec<String>) {
-    // Prepend program name for clap parsing
+fn parse_cli_args(argv: Vec<String>) -> Result<Args, i32> {
     let mut full_args = vec!["rtest".to_string()];
     full_args.extend(argv);
-    let args = Args::parse_from(full_args);
+
+    match Args::try_parse_from(full_args) {
+        Ok(args) => Ok(args),
+        Err(err) => {
+            let _ = err.print();
+            let code = match err.kind() {
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => exit_codes::OK,
+                _ => exit_codes::USAGE_ERROR,
+            };
+            Err(code)
+        }
+    }
+}
+
+fn build_session(py: Python, argv: Vec<String>) -> Result<SessionContext, i32> {
+    let args = parse_cli_args(argv)?;
 
     if let Err(e) = args.validate_dist() {
         eprintln!("Error: {e}");
-        std::process::exit(exit_codes::TESTS_FAILED);
+        return Err(exit_codes::TESTS_FAILED);
     }
 
     let num_processes = match args.get_num_processes() {
         Ok(n) => n,
         Err(e) => {
             eprintln!("Error: {e}");
-            std::process::exit(exit_codes::TESTS_FAILED);
+            return Err(exit_codes::TESTS_FAILED);
         }
     };
     let worker_count = determine_worker_count(num_processes, args.maxprocesses);
@@ -182,144 +59,44 @@ fn main_cli_with_args(py: Python, argv: Vec<String>) {
         Ok(dir) => dir,
         Err(e) => {
             eprintln!("{e}");
-            std::process::exit(exit_codes::TESTS_FAILED);
+            return Err(exit_codes::TESTS_FAILED);
         }
     };
 
-    // Get Python executable from sys.executable
     let python_executable = get_python_executable(py);
+    let pytest_runner = PytestRunner::from_current_python_with_env(py, args.env.clone());
 
-    match args.runner {
-        Runner::Native => {
-            // Use Rust-based collection for consistent output with pytest runner
-            let (test_nodes, errors) = match collect_tests_rust(rootpath.clone(), &args.files) {
-                Ok((nodes, errors)) => (nodes, errors),
-                Err(e) => handle_collection_error(e),
-            };
+    SessionContext::from_parts(
+        args,
+        rootpath,
+        python_executable,
+        pytest_runner,
+        worker_count,
+    )
+    .map_err(|e| {
+        eprintln!("Error: {e}");
+        exit_codes::TESTS_FAILED
+    })
+}
 
-            display_collection_results(&test_nodes, &errors);
+#[pyfunction]
+#[pyo3(signature = (pytest_args=None))]
+fn run_tests(py: Python, pytest_args: Option<Vec<String>>) -> i32 {
+    let argv = pytest_args.unwrap_or_default();
+    let ctx = match build_session(py, argv) {
+        Ok(ctx) => ctx,
+        Err(code) => return code,
+    };
+    run_session(ctx)
+}
 
-            // Exit early if there are collection errors
-            if !errors.errors.is_empty() {
-                std::process::exit(exit_codes::TESTS_FAILED);
-            }
-
-            if test_nodes.is_empty() {
-                println!("No tests found.");
-                std::process::exit(exit_codes::OK);
-            }
-
-            // Exit after collection if --collect-only flag is set
-            if args.collect_only {
-                std::process::exit(exit_codes::OK);
-            }
-
-            // Read pytest configuration for collection patterns
-            let pytest_config = read_pytest_config(&rootpath);
-            let python_files = if pytest_config.python_files.is_empty() {
-                default_python_files()
-            } else {
-                pytest_config.python_files
-            };
-            let python_classes = if pytest_config.python_classes.is_empty() {
-                default_python_classes()
-            } else {
-                pytest_config.python_classes
-            };
-            let python_functions = if pytest_config.python_functions.is_empty() {
-                default_python_functions()
-            } else {
-                pytest_config.python_functions
-            };
-
-            // For execution, still use file-based collection (worker handles discovery)
-            let test_files = collect_test_files(&rootpath, &args.files, &python_files);
-
-            let config = NativeRunnerConfig {
-                python_executable,
-                root_path: rootpath,
-                num_workers: worker_count,
-                python_files,
-                python_classes,
-                python_functions,
-            };
-
-            let exit_code = execute_native(&config, test_files);
-            std::process::exit(exit_code);
-        }
-        Runner::Pytest => {
-            // Legacy pytest-based runner
-            let runner = PytestRunner::from_current_python_with_env(py, args.env.clone());
-
-            let (test_nodes, errors) = match collect_tests_rust(rootpath.clone(), &args.files) {
-                Ok((nodes, errors)) => (nodes, errors),
-                Err(e) => handle_collection_error(e),
-            };
-
-            display_collection_results(&test_nodes, &errors);
-
-            // Exit early if there are collection errors to prevent test execution
-            if !errors.errors.is_empty() {
-                std::process::exit(exit_codes::TESTS_FAILED);
-            }
-
-            if test_nodes.is_empty() {
-                println!("No tests found.");
-                std::process::exit(exit_codes::OK);
-            }
-
-            // Exit after collection if --collect-only flag is set
-            if args.collect_only {
-                std::process::exit(exit_codes::OK);
-            }
-
-            let exit_code = if worker_count == 1 || args.dist == "no" {
-                // Group tests by subproject
-                let test_groups = subproject::group_tests_by_subproject(&rootpath, &test_nodes);
-
-                let mut overall_exit_code = 0;
-
-                for (subproject_root, tests) in test_groups {
-                    if tests.is_empty() {
-                        continue;
-                    }
-
-                    let adjusted_tests = if subproject_root != rootpath {
-                        subproject::make_test_paths_relative(&tests, &rootpath, &subproject_root)
-                    } else {
-                        tests
-                    };
-
-                    let code = execute_tests(
-                        &runner.program,
-                        &runner.initial_args,
-                        adjusted_tests,
-                        vec![],
-                        Some(&subproject_root),
-                        &runner.env_vars,
-                    );
-
-                    if code != 0 {
-                        overall_exit_code = code;
-                    }
-                }
-
-                overall_exit_code
-            } else {
-                let config = ParallelExecutionConfig {
-                    program: &runner.program,
-                    initial_args: &runner.initial_args,
-                    worker_count,
-                    dist_mode: &args.dist,
-                    rootpath: &rootpath,
-                    use_subprojects: true,
-                    env_vars: &runner.env_vars,
-                };
-                execute_tests_parallel(&config, test_nodes)
-            };
-            std::process::exit(exit_code);
-        }
-    }
+#[pyfunction]
+fn main_cli_with_args(py: Python, argv: Vec<String>) {
+    let exit_code = match build_session(py, argv) {
+        Ok(ctx) => run_session(ctx),
+        Err(code) => code,
+    };
+    std::process::exit(exit_code);
 }
 
 #[pymodule]

--- a/src/pytest_executor.rs
+++ b/src/pytest_executor.rs
@@ -1,20 +1,17 @@
 //! Handles the execution of pytest with collected test nodes.
 
+use crate::cache::{parse_junit_xml, TestOutcome};
 use std::path::Path;
 use std::process::Command;
 
+pub struct PytestExecutionResult {
+    pub exit_code: i32,
+    pub outcomes: Vec<(String, TestOutcome)>,
+}
+
 /// Executes pytest with the given program, initial arguments, collected test nodes, and additional pytest arguments.
 ///
-/// # Arguments
-///
-/// * `program` - The pytest executable or package manager command.
-/// * `initial_args` - Initial arguments to pass to the program (e.g., `run` for `uv`).
-/// * `test_nodes` - A `Vec<String>` of test node IDs to execute.
-/// * `pytest_args` - Additional arguments to pass directly to pytest.
-/// * `working_dir` - Optional working directory for pytest execution.
-/// * `env_vars` - Environment variables to set for pytest execution.
-///
-/// Returns the exit code from pytest.
+/// When `junit_xml` is set, passes `--junitxml=PATH` and parses structured outcomes from that file.
 pub fn execute_tests(
     program: &str,
     initial_args: &[String],
@@ -22,11 +19,11 @@ pub fn execute_tests(
     pytest_args: Vec<String>,
     working_dir: Option<&Path>,
     env_vars: &[(String, String)],
-) -> i32 {
+    junit_xml: Option<&Path>,
+) -> PytestExecutionResult {
     let mut run_cmd = Command::new(program);
     run_cmd.args(initial_args);
 
-    // Set environment variables
     for (key, value) in env_vars {
         run_cmd.env(key, value);
     }
@@ -37,19 +34,61 @@ pub fn execute_tests(
         run_cmd.arg(dir);
     }
 
-    run_cmd.args(test_nodes);
-    run_cmd.args(pytest_args);
+    run_cmd.args(&test_nodes);
+    run_cmd.args(&pytest_args);
+
+    if let Some(path) = junit_xml {
+        run_cmd.arg(format!("--junitxml={}", path.display()));
+    }
 
     let run_status = match run_cmd.status() {
         Ok(status) => status,
         Err(e) => {
             log::error!("Failed to execute pytest command: {e}");
-            return 1;
+            return PytestExecutionResult {
+                exit_code: 1,
+                outcomes: vec![],
+            };
         }
     };
 
-    run_status.code().unwrap_or_else(|| {
+    let exit_code = run_status.code().unwrap_or_else(|| {
         log::warn!("Pytest process terminated by signal");
         1
-    })
+    });
+
+    let outcomes = if let Some(path) = junit_xml {
+        parse_junit_xml(path).unwrap_or_else(|e| {
+            log::warn!("Failed to parse junit xml {}: {e}", path.display());
+            Vec::new()
+        })
+    } else {
+        Vec::new()
+    };
+
+    PytestExecutionResult {
+        exit_code,
+        outcomes,
+    }
+}
+
+/// Convenience wrapper when junit outcomes are not needed.
+pub fn execute_tests_exit_code(
+    program: &str,
+    initial_args: &[String],
+    test_nodes: Vec<String>,
+    pytest_args: Vec<String>,
+    working_dir: Option<&Path>,
+    env_vars: &[(String, String)],
+) -> i32 {
+    execute_tests(
+        program,
+        initial_args,
+        test_nodes,
+        pytest_args,
+        working_dir,
+        env_vars,
+        None,
+    )
+    .exit_code
 }

--- a/src/python_discovery/cases.rs
+++ b/src/python_discovery/cases.rs
@@ -750,7 +750,8 @@ mod tests {
     #[test]
     fn test_literal_to_id_string() {
         assert_eq!(literal_to_id_string(&LiteralValue::Int(42)), "42");
-        assert_eq!(literal_to_id_string(&LiteralValue::Float(3.14)), "3.14");
+        let value = 1.23_f64;
+        assert_eq!(literal_to_id_string(&LiteralValue::Float(value)), "1.23");
         assert_eq!(
             literal_to_id_string(&LiteralValue::String("hello".to_string())),
             "hello"

--- a/src/python_discovery/discovery.rs
+++ b/src/python_discovery/discovery.rs
@@ -3,6 +3,8 @@
 use crate::collection::error::{CollectionError, CollectionResult, CollectionWarning};
 use crate::collection::nodes::Function;
 use crate::collection::types::Location;
+use std::collections::HashSet;
+
 use crate::python_discovery::cases::CasesExpansion;
 use crate::python_discovery::module_resolver::ModuleResolver;
 use crate::python_discovery::semantic_analyzer::SemanticTestDiscovery;
@@ -101,6 +103,32 @@ fn path_to_module_path(file_path: &Path, root_path: &Path) -> Vec<String> {
     parts
 }
 
+/// Build pytest-style keyword names used for `-k` expression matching.
+pub fn build_keywords(test: &TestInfo, module_nodeid: &str) -> Vec<String> {
+    let mut names = HashSet::new();
+
+    if let Some(file_part) = module_nodeid.split("::").next() {
+        names.insert(file_part.to_lowercase());
+        if let Some(stem) = Path::new(file_part).file_stem() {
+            names.insert(stem.to_string_lossy().to_lowercase());
+        }
+    }
+
+    if let Some(class_name) = &test.class_name {
+        names.insert(class_name.to_lowercase());
+    }
+    names.insert(test.name.to_lowercase());
+
+    if let CasesExpansion::Expanded(cases) = &test.cases_expansion {
+        for case in cases {
+            names.insert(case.case_id.to_lowercase());
+            names.insert(format!("{}[{}]", test.name, case.case_id).to_lowercase());
+        }
+    }
+
+    names.into_iter().collect()
+}
+
 /// Convert TestInfo to one or more Function collectors.
 ///
 /// Returns multiple Functions if the test has expanded cases (e.g., `test_foo[0]`, `test_foo[1]`).
@@ -115,12 +143,14 @@ pub fn test_info_to_functions(
     } else {
         format!("{}::{}", module_nodeid, test.name)
     };
+    let base_keywords = build_keywords(test, module_nodeid);
 
     match &test.cases_expansion {
         CasesExpansion::NotDecorated | CasesExpansion::CannotExpand(_) => {
             vec![Function {
                 name: test.name.clone(),
                 nodeid: base_nodeid,
+                keywords: base_keywords,
                 location: Location {
                     path: module_path.to_path_buf(),
                     line: Some(test.line),
@@ -133,9 +163,13 @@ pub fn test_info_to_functions(
             .map(|case| {
                 let nodeid = format!("{}[{}]", base_nodeid, case.case_id);
                 let name_with_case = format!("{}[{}]", test.name, case.case_id);
+                let mut keywords = base_keywords.clone();
+                keywords.push(case.case_id.clone());
+                keywords.push(name_with_case.clone());
                 Function {
                     name: name_with_case.clone(),
                     nodeid,
+                    keywords,
                     location: Location {
                         path: module_path.to_path_buf(),
                         line: Some(test.line),

--- a/src/python_discovery/pattern.rs
+++ b/src/python_discovery/pattern.rs
@@ -1,14 +1,12 @@
 //! Pattern matching utilities for test discovery.
 
-/// Check if a name matches a pattern (supports * wildcards)
+use glob::Pattern;
+
+/// Check if a name matches a pytest-style glob pattern (fnmatch / `glob` semantics).
 pub fn matches(pattern: &str, name: &str) -> bool {
-    if let Some(prefix) = pattern.strip_suffix('*') {
-        name.starts_with(prefix)
-    } else if let Some(suffix) = pattern.strip_prefix('*') {
-        name.ends_with(suffix)
-    } else {
-        pattern == name
-    }
+    Pattern::new(pattern)
+        .map(|p| p.matches(name))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -27,5 +25,9 @@ mod tests {
 
         assert!(matches("*_test", "foo_test"));
         assert!(!matches("*_test", "test_foo"));
+
+        assert!(matches("*Test*", "MyTestCase"));
+        assert!(matches("*Test*", "SuiteTestRunner"));
+        assert!(!matches("*Test*", "NoMatch"));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,8 @@
+use crate::cache::{parse_junit_xml, TestOutcome};
+use crate::worker::WorkerResult;
 use crate::{create_scheduler, subproject, DistributionMode, WorkerPool, WorkerTask};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 pub struct PytestRunner {
     pub program: String,
@@ -16,25 +19,31 @@ pub struct ParallelExecutionConfig<'a> {
     pub rootpath: &'a Path,
     pub use_subprojects: bool,
     pub env_vars: &'a [(String, String)],
+    /// Extra pytest CLI args appended after test nodeids.
+    pub worker_pytest_args: &'a [String],
+}
+
+fn parse_env_vars(env_vars: &[String], warn_invalid: bool) -> Vec<(String, String)> {
+    env_vars
+        .iter()
+        .filter_map(|env_str| {
+            if let Some((key, value)) = env_str.split_once('=') {
+                Some((key.to_string(), value.to_string()))
+            } else {
+                if warn_invalid {
+                    log::warn!("Invalid environment variable format: {}", env_str);
+                }
+                None
+            }
+        })
+        .collect()
 }
 
 impl PytestRunner {
     pub fn new(env_vars: Vec<String>) -> Self {
         let program = "python3".into();
         let initial_args = vec!["-m".into(), "pytest".into()];
-
-        // Parse environment variables from KEY=VALUE format
-        let parsed_env_vars: Vec<(String, String)> = env_vars
-            .iter()
-            .filter_map(|env_str| {
-                if let Some((key, value)) = env_str.split_once('=') {
-                    Some((key.to_string(), value.to_string()))
-                } else {
-                    log::warn!("Invalid environment variable format: {}", env_str);
-                    None
-                }
-            })
-            .collect();
+        let parsed_env_vars = parse_env_vars(&env_vars, true);
 
         log::debug!("Pytest command: {} {}", program, initial_args.join(" "));
 
@@ -44,10 +53,42 @@ impl PytestRunner {
             env_vars: parsed_env_vars,
         }
     }
+
+    #[cfg(feature = "extension-module")]
+    pub fn from_current_python(py: pyo3::Python<'_>) -> Self {
+        use pyo3::types::PyAnyMethods;
+
+        let python_path = py
+            .import("sys")
+            .and_then(|sys| sys.getattr("executable"))
+            .and_then(|exe| exe.extract::<String>())
+            .unwrap_or_else(|_| "python3".to_string());
+
+        Self {
+            program: python_path,
+            initial_args: vec!["-m".to_string(), "pytest".to_string()],
+            env_vars: vec![],
+        }
+    }
+
+    #[cfg(feature = "extension-module")]
+    pub fn from_current_python_with_env(py: pyo3::Python<'_>, env_vars: Vec<String>) -> Self {
+        let mut runner = Self::from_current_python(py);
+        runner.env_vars = parse_env_vars(&env_vars, false);
+        runner
+    }
 }
 
-/// Execute tests in parallel across multiple workers
+/// Execute tests in parallel across multiple workers.
 pub fn execute_tests_parallel(config: &ParallelExecutionConfig, test_nodes: Vec<String>) -> i32 {
+    execute_tests_parallel_with_outcomes(config, test_nodes).0
+}
+
+/// Run tests in parallel and return exit code plus structured outcomes from `--junitxml` reports.
+pub fn execute_tests_parallel_with_outcomes(
+    config: &ParallelExecutionConfig,
+    test_nodes: Vec<String>,
+) -> (i32, Vec<(String, TestOutcome)>) {
     log::info!(
         "Running tests with {} workers using {} distribution",
         config.worker_count,
@@ -58,15 +99,42 @@ pub fn execute_tests_parallel(config: &ParallelExecutionConfig, test_nodes: Vec<
         Ok(mode) => mode,
         Err(e) => {
             log::warn!("Invalid distribution mode '{}': {e}", config.dist_mode);
-            return 1;
+            return (1, Vec::new());
         }
+    };
+
+    let junit_dir = match TempDir::with_prefix("rtest-junit-") {
+        Ok(dir) => dir,
+        Err(e) => {
+            log::error!("Failed to create junit temp directory: {e}");
+            return (1, Vec::new());
+        }
+    };
+
+    let mut junit_paths: Vec<PathBuf> = Vec::new();
+    let mut worker_pool = WorkerPool::new();
+    let mut worker_id = 0;
+
+    let spawn_batch = |pool: &mut WorkerPool,
+                       id: usize,
+                       batch: Vec<String>,
+                       working_dir: PathBuf,
+                       junit_path: PathBuf| {
+        let mut pytest_args = config.worker_pytest_args.to_vec();
+        pytest_args.push(format!("--junitxml={}", junit_path.display()));
+        pool.spawn_worker(WorkerTask {
+            worker_id: id,
+            program: config.program.to_string(),
+            initial_args: config.initial_args.to_vec(),
+            tests: batch,
+            pytest_args,
+            working_dir: Some(working_dir),
+            env_vars: config.env_vars.to_vec(),
+        });
     };
 
     if config.use_subprojects {
         let test_groups = subproject::group_tests_by_subproject(config.rootpath, &test_nodes);
-
-        let mut worker_pool = WorkerPool::new();
-        let mut worker_id = 0;
 
         for (subproject_root, tests) in test_groups {
             let adjusted_tests = if subproject_root != config.rootpath {
@@ -80,87 +148,78 @@ pub fn execute_tests_parallel(config: &ParallelExecutionConfig, test_nodes: Vec<
 
             for batch in test_batches {
                 if !batch.is_empty() {
-                    worker_pool.spawn_worker(WorkerTask {
+                    let junit_path = junit_dir.path().join(format!("worker-{worker_id}.xml"));
+                    junit_paths.push(junit_path.clone());
+                    spawn_batch(
+                        &mut worker_pool,
                         worker_id,
-                        program: config.program.to_string(),
-                        initial_args: config.initial_args.to_vec(),
-                        tests: batch,
-                        pytest_args: vec![],
-                        working_dir: Some(subproject_root.clone()),
-                        env_vars: config.env_vars.to_vec(),
-                    });
+                        batch,
+                        subproject_root.clone(),
+                        junit_path,
+                    );
                     worker_id += 1;
                 }
             }
         }
-
-        if worker_id == 0 {
-            log::info!("No test batches to execute.");
-            return 0;
-        }
-
-        let results = worker_pool.wait_for_all();
-
-        let mut overall_exit_code = 0;
-        for result in results {
-            println!("=== Worker {} ===", result.worker_id);
-            if !result.stdout.is_empty() {
-                print!("{}", result.stdout);
-            }
-            if !result.stderr.is_empty() {
-                eprint!("{}", result.stderr);
-            }
-
-            if result.exit_code != 0 {
-                overall_exit_code = result.exit_code;
-            }
-        }
-
-        overall_exit_code
     } else {
         let scheduler = create_scheduler(distribution_mode);
         let test_batches = scheduler.distribute_tests(test_nodes, config.worker_count);
 
-        if test_batches.is_empty() {
-            log::info!("No test batches to execute.");
-            return 0;
-        }
-
-        let mut worker_pool = WorkerPool::new();
-
-        for (worker_id, tests) in test_batches.into_iter().enumerate() {
-            if !tests.is_empty() {
-                worker_pool.spawn_worker(WorkerTask {
+        for batch in test_batches {
+            if !batch.is_empty() {
+                let junit_path = junit_dir.path().join(format!("worker-{worker_id}.xml"));
+                junit_paths.push(junit_path.clone());
+                spawn_batch(
+                    &mut worker_pool,
                     worker_id,
-                    program: config.program.to_string(),
-                    initial_args: config.initial_args.to_vec(),
-                    tests,
-                    pytest_args: vec![],
-                    working_dir: Some(config.rootpath.to_path_buf()),
-                    env_vars: config.env_vars.to_vec(),
-                });
+                    batch,
+                    config.rootpath.to_path_buf(),
+                    junit_path,
+                );
+                worker_id += 1;
             }
         }
-
-        let results = worker_pool.wait_for_all();
-
-        let mut overall_exit_code = 0;
-        for result in results {
-            println!("=== Worker {} ===", result.worker_id);
-            if !result.stdout.is_empty() {
-                print!("{}", result.stdout);
-            }
-            if !result.stderr.is_empty() {
-                eprint!("{}", result.stderr);
-            }
-
-            if result.exit_code != 0 {
-                overall_exit_code = result.exit_code;
-            }
-        }
-
-        overall_exit_code
     }
+
+    if worker_id == 0 {
+        log::info!("No test batches to execute.");
+        return (0, Vec::new());
+    }
+
+    let results = worker_pool.wait_for_all();
+    let (exit_code, _) = summarize_worker_results(results);
+
+    let mut outcomes = Vec::new();
+    for path in junit_paths {
+        match parse_junit_xml(&path) {
+            Ok(mut batch) => outcomes.append(&mut batch),
+            Err(e) => log::warn!("Failed to parse junit xml {}: {e}", path.display()),
+        }
+    }
+
+    (exit_code, outcomes)
+}
+
+fn summarize_worker_results(results: Vec<WorkerResult>) -> (i32, String) {
+    let mut overall_exit_code = 0;
+    let mut combined_output = String::new();
+    for result in results {
+        println!("=== Worker {} ===", result.worker_id);
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
+            combined_output.push_str(&result.stdout);
+        }
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+            combined_output.push_str(&result.stderr);
+        }
+
+        if result.exit_code != 0 {
+            overall_exit_code = result.exit_code;
+        }
+    }
+
+    (overall_exit_code, combined_output)
 }
 
 #[cfg(test)]
@@ -180,8 +239,6 @@ mod tests {
         let env_vars = vec!["DEBUG=1".into(), "TEST_ENV=staging".into()];
         let runner = PytestRunner::new(env_vars);
 
-        // The runner should be created successfully
-        // (Environment variables are currently just acknowledged, not stored)
         assert_eq!(runner.program, "python3");
         assert_eq!(runner.initial_args, vec!["-m", "pytest"]);
     }
@@ -207,14 +264,15 @@ mod tests {
 
     #[test]
     fn test_execute_tests_nonexistent_program() {
-        let exit_code = crate::pytest_executor::execute_tests(
+        let result = crate::pytest_executor::execute_tests(
             "nonexistent_program_xyz_12345",
             &[],
             vec!["test::something".into()],
             vec![],
             None,
             &[],
+            None,
         );
-        assert_eq!(exit_code, 1);
+        assert_eq!(result.exit_code, 1);
     }
 }

--- a/src/selection/expression.rs
+++ b/src/selection/expression.rs
@@ -1,0 +1,262 @@
+//! Boolean expression parser for `-k`.
+//!
+//! Compatibility target: pytest's `_pytest.mark.expression` (and/or/not, parentheses).
+//! Nodeids may contain `::`, `[]`, and path separators; identifiers in expressions match
+//! against collected keyword names via substring (case-insensitive).
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Ident(String),
+    Or,
+    And,
+    Not,
+    LParen,
+    RParen,
+    Eof,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseError {
+    pub column: usize,
+    pub message: String,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "at column {}: {}", self.column, self.message)
+    }
+}
+
+struct Scanner {
+    input: Vec<char>,
+    pos: usize,
+}
+
+impl Scanner {
+    fn new(input: &str) -> Self {
+        Self {
+            input: input.chars().collect(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<char> {
+        let ch = self.peek()?;
+        self.pos += 1;
+        Some(ch)
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(' ' | '\t')) {
+            self.advance();
+        }
+    }
+
+    fn column(&self) -> usize {
+        self.pos + 1
+    }
+
+    fn next_token(&mut self) -> Result<Token, ParseError> {
+        self.skip_whitespace();
+        let col = self.column();
+        let Some(ch) = self.peek() else {
+            return Ok(Token::Eof);
+        };
+
+        match ch {
+            '(' => {
+                self.advance();
+                Ok(Token::LParen)
+            }
+            ')' => {
+                self.advance();
+                Ok(Token::RParen)
+            }
+            _ => {
+                let start = self.pos;
+                while let Some(c) = self.peek() {
+                    if c.is_ascii_alphanumeric()
+                        || c == '_'
+                        || c == ':'
+                        || c == '+'
+                        || c == '-'
+                        || c == '.'
+                        || c == '['
+                        || c == ']'
+                        || c == '\\'
+                        || c == '/'
+                    {
+                        self.advance();
+                    } else if c.is_whitespace() || c == '(' || c == ')' {
+                        break;
+                    } else {
+                        return Err(ParseError {
+                            column: self.column(),
+                            message: format!("unexpected character \"{c}\""),
+                        });
+                    }
+                }
+                let value: String = self.input[start..self.pos].iter().collect();
+                if value.is_empty() {
+                    return Err(ParseError {
+                        column: col,
+                        message: format!("unexpected character \"{ch}\""),
+                    });
+                }
+                match value.as_str() {
+                    "or" => Ok(Token::Or),
+                    "and" => Ok(Token::And),
+                    "not" => Ok(Token::Not),
+                    _ => Ok(Token::Ident(value)),
+                }
+            }
+        }
+    }
+}
+
+struct Parser {
+    current: Token,
+    scanner: Scanner,
+}
+
+impl Parser {
+    fn new(input: &str) -> Result<Self, ParseError> {
+        let mut scanner = Scanner::new(input);
+        let current = scanner.next_token()?;
+        Ok(Self { current, scanner })
+    }
+
+    fn advance(&mut self) -> Result<(), ParseError> {
+        self.current = self.scanner.next_token()?;
+        Ok(())
+    }
+
+    fn accept(&mut self, token: &Token) -> bool {
+        if &self.current == token {
+            let _ = self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, token: &Token) -> Result<(), ParseError> {
+        if self.accept(token) {
+            Ok(())
+        } else {
+            Err(ParseError {
+                column: self.scanner.column(),
+                message: format!("expected {token:?}; got {:?}", self.current),
+            })
+        }
+    }
+
+    fn parse(mut self) -> Result<Expr, ParseError> {
+        if matches!(self.current, Token::Eof) {
+            return Ok(Expr::Const(false));
+        }
+        let expr = self.parse_or()?;
+        self.expect(&Token::Eof)?;
+        Ok(expr)
+    }
+
+    fn parse_or(&mut self) -> Result<Expr, ParseError> {
+        let mut left = self.parse_and()?;
+        while self.accept(&Token::Or) {
+            let right = self.parse_and()?;
+            left = Expr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<Expr, ParseError> {
+        let mut left = self.parse_not()?;
+        while self.accept(&Token::And) {
+            let right = self.parse_not()?;
+            left = Expr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_not(&mut self) -> Result<Expr, ParseError> {
+        if self.accept(&Token::Not) {
+            Ok(Expr::Not(Box::new(self.parse_not()?)))
+        } else if self.accept(&Token::LParen) {
+            let inner = self.parse_or()?;
+            self.expect(&Token::RParen)?;
+            Ok(inner)
+        } else if let Token::Ident(name) = self.current.clone() {
+            self.advance()?;
+            Ok(Expr::Ident(name))
+        } else {
+            Err(ParseError {
+                column: self.scanner.column(),
+                message: format!("expected not, (, or identifier; got {:?}", self.current),
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Expr {
+    Const(bool),
+    Ident(String),
+    Or(Box<Expr>, Box<Expr>),
+    And(Box<Expr>, Box<Expr>),
+    Not(Box<Expr>),
+}
+
+impl Expr {
+    fn eval<M: Fn(&str) -> bool>(&self, matcher: &M) -> bool {
+        match self {
+            Expr::Const(v) => *v,
+            Expr::Ident(name) => matcher(name),
+            Expr::Or(a, b) => a.eval(matcher) || b.eval(matcher),
+            Expr::And(a, b) => a.eval(matcher) && b.eval(matcher),
+            Expr::Not(a) => !a.eval(matcher),
+        }
+    }
+}
+
+/// Parsed `-k` expression for repeated evaluation.
+#[derive(Debug, Clone)]
+pub struct CompiledExpression(Expr);
+
+/// Parse a `-k` expression once for repeated evaluation.
+pub fn compile_expression(input: &str) -> Result<CompiledExpression, ParseError> {
+    let parser = Parser::new(input)?;
+    parser.parse().map(CompiledExpression)
+}
+
+/// Evaluate a compiled `-k` expression against a keyword matcher function.
+pub fn evaluate_compiled(expr: &CompiledExpression, matcher: impl Fn(&str) -> bool) -> bool {
+    expr.0.eval(&matcher)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eval(input: &str, matcher: impl Fn(&str) -> bool) -> bool {
+        let expr = compile_expression(input).unwrap();
+        evaluate_compiled(&expr, matcher)
+    }
+
+    #[test]
+    fn test_empty_expression_is_false() {
+        assert!(!eval("", |_| true));
+    }
+
+    #[test]
+    fn test_and_or_not() {
+        let m = |name: &str| name == "foo" || name == "bar";
+        assert!(eval("foo", m));
+        assert!(eval("foo and bar", m));
+        assert!(eval("foo or baz", m));
+        assert!(!eval("not foo", m));
+    }
+}

--- a/src/selection/keyword.rs
+++ b/src/selection/keyword.rs
@@ -1,0 +1,16 @@
+//! Keyword matching for `-k` expressions.
+
+use crate::collection_integration::CollectedItem;
+
+/// Returns true if `ident` matches any keyword (case-insensitive substring).
+///
+/// Keywords are stored lowercased at collection time; only `ident` is normalized per lookup.
+pub fn ident_matches_keywords(ident: &str, keywords: &[String]) -> bool {
+    let ident_lower = ident.to_lowercase();
+    keywords.iter().any(|kw| kw.contains(&ident_lower))
+}
+
+/// Returns true if the item matches the given identifier.
+pub fn item_matches_ident(item: &CollectedItem, ident: &str) -> bool {
+    ident_matches_keywords(ident, &item.keywords)
+}

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -1,0 +1,97 @@
+//! Post-collection test selection (`-k`, `--lf`, `--ff`).
+
+mod expression;
+mod keyword;
+
+use crate::cache::{apply_last_failed, CacheError, LastFailedMode, LastFailedNoFailures};
+use crate::collection_integration::CollectedItem;
+
+pub use expression::ParseError;
+
+/// Apply all post-collection selection steps in order: cache modes, then `-k`.
+pub fn apply_selection(
+    items: Vec<CollectedItem>,
+    keyword_expr: Option<&str>,
+    last_failed: bool,
+    failed_first: bool,
+    lfnf: LastFailedNoFailures,
+    cache_dir: &std::path::Path,
+) -> Result<(Vec<CollectedItem>, SelectionStats), SelectionError> {
+    let initial_count = items.len();
+    let mut current = items;
+
+    if last_failed || failed_first {
+        let mode = if last_failed {
+            LastFailedMode::LastFailed
+        } else {
+            LastFailedMode::FailedFirst
+        };
+        current =
+            apply_last_failed(current, mode, lfnf, cache_dir).map_err(SelectionError::Cache)?;
+    }
+
+    let after_cache_count = current.len();
+    let mut deselected_by_keyword = 0usize;
+
+    if let Some(expr) = keyword_expr {
+        if expr.is_empty() {
+            return Err(SelectionError::KeywordParse(ParseError {
+                column: 1,
+                message: "empty expression".into(),
+            }));
+        }
+        let compiled =
+            expression::compile_expression(expr).map_err(SelectionError::KeywordParse)?;
+        let before = current.len();
+        current = apply_keyword_filter(current, &compiled)?;
+        deselected_by_keyword = before.saturating_sub(current.len());
+    }
+
+    let deselected = initial_count
+        .saturating_sub(after_cache_count)
+        .saturating_add(deselected_by_keyword);
+
+    Ok((
+        current,
+        SelectionStats {
+            deselected,
+            deselected_by_keyword,
+        },
+    ))
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SelectionStats {
+    pub deselected: usize,
+    pub deselected_by_keyword: usize,
+}
+
+#[derive(Debug)]
+pub enum SelectionError {
+    KeywordParse(ParseError),
+    Cache(CacheError),
+}
+
+impl std::fmt::Display for SelectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SelectionError::KeywordParse(e) => write!(f, "Invalid -k expression {e}"),
+            SelectionError::Cache(e) => write!(f, "Cache error: {e}"),
+        }
+    }
+}
+
+pub fn apply_keyword_filter(
+    items: Vec<CollectedItem>,
+    expr: &expression::CompiledExpression,
+) -> Result<Vec<CollectedItem>, SelectionError> {
+    let mut kept = Vec::new();
+    for item in items {
+        let matches =
+            expression::evaluate_compiled(expr, |ident| keyword::item_matches_ident(&item, ident));
+        if matches {
+            kept.push(item);
+        }
+    }
+    Ok(kept)
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,265 @@
+//! CLI session orchestration: collect → select → display → run.
+//!
+//! Selection (`-k`, `--lf`, `--ff`) is applied in the coordinator after collection.
+//! Runners receive final nodeids only; they must not re-apply keyword or cache filters.
+
+use crate::cache::{
+    cache_dir_for_root, clear_cache, update_lastfailed_from_outcomes, LastFailedNoFailures,
+};
+use crate::cli::{exit_codes, Args, Runner};
+use crate::collection::error::CollectionError;
+use crate::collection_integration::{
+    collect_tests_rust, display_collection_results, CollectedItem, CollectionDisplayStats,
+    CollectionErrors,
+};
+use crate::config::{read_pytest_config, PytestConfig};
+use crate::native_runner::{
+    default_python_classes, default_python_files, default_python_functions, execute_native,
+    files_from_nodeids, NativeRunnerConfig,
+};
+use crate::pytest_executor::execute_tests;
+use crate::runner::{execute_tests_parallel_with_outcomes, ParallelExecutionConfig, PytestRunner};
+use crate::selection::{apply_selection, SelectionError};
+use crate::subproject;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+pub struct SessionContext {
+    pub args: Args,
+    pub rootpath: PathBuf,
+    pub python_executable: String,
+    pub pytest_runner: PytestRunner,
+    pub worker_count: usize,
+    pub pytest_config: PytestConfig,
+    pub cache_dir: PathBuf,
+    pub lfnf: LastFailedNoFailures,
+}
+
+impl SessionContext {
+    pub fn from_parts(
+        args: Args,
+        rootpath: PathBuf,
+        python_executable: String,
+        pytest_runner: PytestRunner,
+        worker_count: usize,
+    ) -> Result<Self, String> {
+        let pytest_config = read_pytest_config(&rootpath);
+        let cache_dir = cache_dir_for_root(&rootpath, pytest_config.cache_dir.as_ref());
+        let lfnf = args.lfnf.parse()?;
+        Ok(Self {
+            args,
+            rootpath,
+            python_executable,
+            pytest_runner,
+            worker_count,
+            pytest_config,
+            cache_dir,
+            lfnf,
+        })
+    }
+}
+
+pub fn handle_collection_error(e: CollectionError) -> ! {
+    match e {
+        CollectionError::FileNotFound(path) => {
+            eprintln!("ERROR: file or directory not found: {}", path.display());
+            std::process::exit(exit_codes::USAGE_ERROR);
+        }
+        e => {
+            eprintln!("FATAL: {e}");
+            std::process::exit(exit_codes::TESTS_FAILED);
+        }
+    }
+}
+
+fn apply_cache_clear(ctx: &SessionContext) {
+    if ctx.args.cache_clear {
+        if let Err(e) = clear_cache(&ctx.cache_dir) {
+            eprintln!("Warning: failed to clear cache: {e}");
+        }
+    }
+}
+
+fn python_files(config: &PytestConfig) -> Vec<String> {
+    if config.python_files.is_empty() {
+        default_python_files()
+    } else {
+        config.python_files.clone()
+    }
+}
+
+fn python_classes(config: &PytestConfig) -> Vec<String> {
+    if config.python_classes.is_empty() {
+        default_python_classes()
+    } else {
+        config.python_classes.clone()
+    }
+}
+
+fn python_functions(config: &PytestConfig) -> Vec<String> {
+    if config.python_functions.is_empty() {
+        default_python_functions()
+    } else {
+        config.python_functions.clone()
+    }
+}
+
+fn collect_and_select(
+    ctx: &SessionContext,
+    file_args: &[String],
+) -> Result<(Vec<CollectedItem>, CollectionErrors, usize), SelectionError> {
+    let (items, errors) = match collect_tests_rust(ctx.rootpath.clone(), file_args) {
+        Ok(result) => result,
+        Err(e) => handle_collection_error(e),
+    };
+
+    let (selected, stats) = apply_selection(
+        items,
+        ctx.args.keyword_expr.as_deref(),
+        ctx.args.last_failed,
+        ctx.args.failed_first,
+        ctx.lfnf,
+        &ctx.cache_dir,
+    )?;
+
+    Ok((selected, errors, stats.deselected))
+}
+
+pub fn run_session(ctx: SessionContext) -> i32 {
+    apply_cache_clear(&ctx);
+
+    let file_args = ctx.args.files.clone();
+    let collect_result = collect_and_select(&ctx, &file_args);
+
+    let (items, errors, deselected) = match collect_result {
+        Ok(result) => result,
+        Err(SelectionError::KeywordParse(e)) => {
+            eprintln!("ERROR: Invalid -k expression {e}");
+            return exit_codes::USAGE_ERROR;
+        }
+        Err(SelectionError::Cache(e)) => {
+            eprintln!("ERROR: {e}");
+            return exit_codes::TESTS_FAILED;
+        }
+    };
+
+    display_collection_results(&items, &errors, CollectionDisplayStats { deselected });
+
+    if !errors.errors.is_empty() {
+        return exit_codes::TESTS_FAILED;
+    }
+
+    if items.is_empty() {
+        if ctx.args.last_failed && ctx.lfnf == LastFailedNoFailures::None {
+            return exit_codes::OK;
+        }
+        println!("No tests found.");
+        return exit_codes::OK;
+    }
+
+    if ctx.args.collect_only {
+        return exit_codes::OK;
+    }
+
+    match ctx.args.runner {
+        Runner::Native => run_native(&ctx, items),
+        Runner::Pytest => run_pytest(&ctx, items),
+    }
+}
+
+fn run_native(ctx: &SessionContext, items: Vec<CollectedItem>) -> i32 {
+    let test_files = files_from_nodeids(&ctx.rootpath, &items);
+    let selected_nodeids = CollectedItem::nodeids(&items);
+
+    let config = NativeRunnerConfig {
+        python_executable: ctx.python_executable.clone(),
+        root_path: ctx.rootpath.clone(),
+        num_workers: ctx.worker_count,
+        python_files: python_files(&ctx.pytest_config),
+        python_classes: python_classes(&ctx.pytest_config),
+        python_functions: python_functions(&ctx.pytest_config),
+        selected_nodeids,
+    };
+
+    let result = execute_native(&config, test_files);
+    if let Err(e) = update_lastfailed_from_outcomes(&ctx.cache_dir, &result.outcomes) {
+        eprintln!("Warning: failed to update failure cache: {e}");
+    }
+    result.exit_code
+}
+
+fn run_pytest(ctx: &SessionContext, items: Vec<CollectedItem>) -> i32 {
+    let test_nodes = CollectedItem::nodeids(&items);
+
+    if ctx.worker_count == 1 || ctx.args.dist == "no" {
+        return run_pytest_serial(ctx, test_nodes);
+    }
+
+    let config = ParallelExecutionConfig {
+        program: &ctx.pytest_runner.program,
+        initial_args: &ctx.pytest_runner.initial_args,
+        worker_count: ctx.worker_count,
+        dist_mode: &ctx.args.dist,
+        rootpath: &ctx.rootpath,
+        use_subprojects: true,
+        env_vars: &ctx.pytest_runner.env_vars,
+        worker_pytest_args: &[],
+    };
+    let (exit_code, outcomes) = execute_tests_parallel_with_outcomes(&config, test_nodes);
+    if let Err(e) = update_lastfailed_from_outcomes(&ctx.cache_dir, &outcomes) {
+        eprintln!("Warning: failed to update failure cache: {e}");
+    }
+    exit_code
+}
+
+fn run_pytest_serial(ctx: &SessionContext, test_nodes: Vec<String>) -> i32 {
+    let junit_dir = match TempDir::with_prefix("rtest-junit-serial-") {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("Failed to create junit temp directory: {e}");
+            return exit_codes::TESTS_FAILED;
+        }
+    };
+
+    let test_groups = subproject::group_tests_by_subproject(&ctx.rootpath, &test_nodes);
+    let mut overall_exit_code = 0;
+    let mut all_outcomes = Vec::new();
+    let mut batch_index = 0usize;
+
+    for (subproject_root, tests) in test_groups {
+        if tests.is_empty() {
+            continue;
+        }
+
+        let adjusted_tests = if subproject_root != ctx.rootpath {
+            subproject::make_test_paths_relative(&tests, &ctx.rootpath, &subproject_root)
+        } else {
+            tests
+        };
+
+        let junit_path = junit_dir.path().join(format!("batch-{batch_index}.xml"));
+        batch_index += 1;
+
+        let result = execute_tests(
+            &ctx.pytest_runner.program,
+            &ctx.pytest_runner.initial_args,
+            adjusted_tests,
+            vec![],
+            Some(&subproject_root),
+            &ctx.pytest_runner.env_vars,
+            Some(&junit_path),
+        );
+
+        all_outcomes.extend(result.outcomes);
+
+        if result.exit_code != 0 {
+            overall_exit_code = result.exit_code;
+        }
+    }
+
+    if let Err(e) = update_lastfailed_from_outcomes(&ctx.cache_dir, &all_outcomes) {
+        eprintln!("Warning: failed to update failure cache: {e}");
+    }
+
+    overall_exit_code
+}

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -40,6 +40,141 @@ class TestCLIBasics:
         )
         assert result.returncode != 0
 
+    def test_help_shows_selection_flags(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "rtest", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == ExitCodeValues.OK
+        assert "-k" in result.stdout
+        assert "--lf" in result.stdout
+        assert "--ff" in result.stdout
+
+
+class TestKeywordSelection:
+    """Tests for -k expression filtering."""
+
+    def test_collect_only_keyword_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_alpha.py").write_text("def test_one(): pass\n")
+            (tmp_path / "test_beta.py").write_text("def test_two(): pass\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--collect-only",
+                    "-k",
+                    "alpha",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.OK
+            assert "test_alpha.py::test_one" in result.stdout
+            assert "test_beta.py" not in result.stdout
+            assert "deselected" in result.stdout
+
+    def test_keyword_expression_and_not(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_items.py").write_text("def test_fast(): pass\ndef test_slow(): pass\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--collect-only",
+                    "-k",
+                    "fast and not slow",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.OK
+            assert "test_fast" in result.stdout
+            assert "test_slow" not in result.stdout
+
+    def test_invalid_keyword_expression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_x.py").write_text("def test_x(): pass\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--collect-only",
+                    "-k",
+                    "(((",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.USAGE_ERROR
+            assert "Invalid -k expression" in result.stderr
+
+
+class TestLastFailedSelection:
+    """Tests for --lf / --ff failure cache."""
+
+    def test_last_failed_runs_only_previous_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_lf.py").write_text("def test_passes(): assert True\ndef test_fails(): assert False\n")
+
+            first = subprocess.run(
+                [sys.executable, "-m", "rtest"],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert first.returncode == ExitCodeValues.TESTS_FAILED
+
+            second = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--collect-only",
+                    "--lf",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert second.returncode == ExitCodeValues.OK
+            assert "test_lf.py::test_fails" in second.stdout
+            assert "test_lf.py::test_passes" not in second.stdout
+
+    def test_lfnf_none_with_empty_cache_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_ok.py").write_text("def test_ok(): assert True\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--lf",
+                    "--lfnf",
+                    "none",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.OK
+
 
 class TestCLIErrorHandling:
     """Tests for error handling."""
@@ -114,3 +249,81 @@ class TestNativeRunnerEndToEnd:
             )
             assert result.returncode == ExitCodeValues.TESTS_FAILED
             assert "ModuleNotFoundError" in result.stdout
+
+    def test_native_runner_keyword_filter_collect_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_alpha.py").write_text("def test_one(): pass\n")
+            (tmp_path / "test_beta.py").write_text("def test_two(): pass\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--runner",
+                    "native",
+                    "--collect-only",
+                    "-k",
+                    "beta",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.OK
+            assert "test_beta.py::test_two" in result.stdout
+            assert "test_alpha.py" not in result.stdout
+
+    def test_native_runner_keyword_filter_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_alpha.py").write_text("def test_one(): assert True\n")
+            (tmp_path / "test_beta.py").write_text("def test_other(): assert False\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--runner",
+                    "native",
+                    "-k",
+                    "alpha",
+                    "-n",
+                    "1",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.OK
+            assert "1 passed" in result.stdout
+            assert "FAILED" not in result.stdout
+
+    def test_native_runner_keyword_filter_single_file(self) -> None:
+        """`-k` must not run deselected tests in the same file."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / "test_mixed.py").write_text("def test_passes(): assert True\ndef test_fails(): assert False\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "rtest",
+                    "--runner",
+                    "native",
+                    "-k",
+                    "passes",
+                    "-n",
+                    "1",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(tmp_path),
+            )
+            assert result.returncode == ExitCodeValues.OK
+            assert "1 passed" in result.stdout
+            assert "test_fails" not in result.stdout
+            assert "FAILED" not in result.stdout

--- a/tests/test_multiple_errors.rs
+++ b/tests/test_multiple_errors.rs
@@ -1,7 +1,9 @@
 //! Test that multiple syntax errors are collected and reported
 
 use indoc::indoc;
-use rtest::collection_integration::{collect_tests_rust, display_collection_results};
+use rtest::collection_integration::{
+    collect_tests_rust, display_collection_results, CollectionDisplayStats,
+};
 use rtest::CollectionError;
 use std::fs;
 use tempfile::TempDir;
@@ -53,10 +55,10 @@ fn test_collection_multiple_syntax_errors() {
     assert_eq!(test_nodes.len(), 2, "Should find tests from valid file");
     assert!(test_nodes
         .iter()
-        .any(|n| n.contains("test_valid.py::test_valid")));
-    assert!(test_nodes
-        .iter()
-        .any(|n| n.contains("test_valid.py::TestValidClass::test_method")));
+        .any(|n| n.nodeid.contains("test_valid.py::test_valid")));
+    assert!(test_nodes.iter().any(|n| n
+        .nodeid
+        .contains("test_valid.py::TestValidClass::test_method")));
 
     assert_eq!(errors.errors.len(), 3, "Should collect all 3 syntax errors");
 
@@ -78,6 +80,6 @@ fn test_collection_multiple_syntax_errors() {
     }
 
     println!("\n--- Test output ---");
-    display_collection_results(&test_nodes, &errors);
+    display_collection_results(&test_nodes, &errors, CollectionDisplayStats::default());
     println!("--- End test output ---\n");
 }


### PR DESCRIPTION
Coordinator-side test selection runs after Rust collection and before execution, so both pytest and native runners only see filtered nodeids. Keyword filtering uses a Rust `-k` expression parser; last-failed behavior reads and updates pytest’s `.pytest_cache/v/cache/lastfailed` from the coordinator (structured JUnit outcomes for pytest, JSONL for native). The CLI and `run_tests()` both go through `run_session`.

## Changed Interfaces

### CLI

| Flag | Description |
|------|-------------|
| `-k EXPRESSION` | Keyword filter (`and` / `or` / `not`, parentheses) |
| `--lf` / `--last-failed` | Rerun failures from cache |
| `--ff` / `--failed-first` | Failures first, then the rest (conflicts with `--lf`) |
| `--lfnf {all,none}` | When `--lf` has no cached failures |
| `--cache-clear` | Remove `lastfailed` before the run |

### Native worker (`python -m rtest.worker`)

| Flag | Description |
|------|-------------|
| `--nodeids-file PATH` | Optional allowlist (one nodeid per line) |